### PR TITLE
Fork MinIO NAS Gateway functionality to PanFS backend

### DIFF
--- a/cmd/gateway-interface.go
+++ b/cmd/gateway-interface.go
@@ -17,6 +17,8 @@
 
 package cmd
 
+import "github.com/minio/madmin-go"
+
 // Gateway name backends
 const (
 	NASBackendGateway   = "nas"

--- a/cmd/gateway-interface.go
+++ b/cmd/gateway-interface.go
@@ -17,12 +17,11 @@
 
 package cmd
 
-import "github.com/minio/madmin-go"
-
 // Gateway name backends
 const (
-	NASBackendGateway = "nas"
-	S3BackendGateway  = "s3"
+	NASBackendGateway   = "nas"
+	PANFSBackendGateway = "panfs"
+	S3BackendGateway    = "s3"
 )
 
 // Gateway represents a gateway backend.

--- a/cmd/gateway/gateway.go
+++ b/cmd/gateway/gateway.go
@@ -22,6 +22,9 @@ import (
 	// NAS
 	_ "github.com/minio/minio/cmd/gateway/nas"
 
+	// PANFS
+	_ "github.com/minio/minio/cmd/gateway/panfs"
+
 	// S3
 	_ "github.com/minio/minio/cmd/gateway/s3"
 	// gateway functionality is frozen, no new gateways are being implemented

--- a/cmd/gateway/panfs/gateway-panfs.go
+++ b/cmd/gateway/panfs/gateway-panfs.go
@@ -1,0 +1,115 @@
+/*
+ * MinIO Object Storage (c) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package panfs
+
+import (
+	"context"
+
+	"github.com/minio/cli"
+	minio "github.com/minio/minio/cmd"
+)
+
+func init() {
+	const panfsGatewayTemplate = `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} {{if .VisibleFlags}}[FLAGS]{{end}} PATH
+{{if .VisibleFlags}}
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}{{end}}
+PATH:
+  path to PANFS mount point
+
+EXAMPLES:
+  1. Start minio gateway server for PANFS backend
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_USER{{.AssignmentOperator}}accesskey
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_PASSWORD{{.AssignmentOperator}}secretkey
+     {{.Prompt}} {{.HelpName}} /shared/panfsvol
+
+  2. Start minio gateway server for PANFS with edge caching enabled
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_USER{{.AssignmentOperator}}accesskey
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_PASSWORD{{.AssignmentOperator}}secretkey
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_DRIVES{{.AssignmentOperator}}"/mnt/drive1,/mnt/drive2,/mnt/drive3,/mnt/drive4"
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_EXCLUDE{{.AssignmentOperator}}"bucket1/*,*.png"
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_QUOTA{{.AssignmentOperator}}90
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_AFTER{{.AssignmentOperator}}3
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_WATERMARK_LOW{{.AssignmentOperator}}75
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_WATERMARK_HIGH{{.AssignmentOperator}}85
+     {{.Prompt}} {{.HelpName}} /shared/panfsvol
+`
+
+	minio.RegisterGatewayCommand(cli.Command{
+		Name:               minio.PANFSBackendGateway,
+		Usage:              "Network-attached storage (PANFS)",
+		Action:             panfsGatewayMain,
+		CustomHelpTemplate: panfsGatewayTemplate,
+		HideHelpCommand:    false,
+	})
+}
+
+// Handler for 'minio gateway panfs' command line.
+func panfsGatewayMain(ctx *cli.Context) {
+	// Validate gateway arguments.
+	if !ctx.Args().Present() || ctx.Args().First() == "help" {
+		cli.ShowCommandHelpAndExit(ctx, minio.PANFSBackendGateway, 1)
+	}
+
+	minio.StartGateway(ctx, &PANFS{ctx.Args().First()})
+}
+
+// PANFS implements Gateway.
+type PANFS struct {
+	path string
+}
+
+// Name implements Gateway interface.
+func (g *PANFS) Name() string {
+	return minio.PANFSBackendGateway
+}
+
+// NewGatewayLayer returns panfs gatewaylayer.
+func (g *PANFS) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
+	var err error
+	newObject, err := minio.NewPANFSObjectLayer(g.path)
+	if err != nil {
+		return nil, err
+	}
+	return &panfsObjects{newObject}, nil
+}
+
+// IsListenSupported returns whether listen bucket notification is applicable for this gateway.
+func (n *panfsObjects) IsListenSupported() bool {
+	return false
+}
+
+func (n *panfsObjects) StorageInfo(ctx context.Context) (si minio.StorageInfo, _ []error) {
+	si, errs := n.ObjectLayer.StorageInfo(ctx)
+	si.Backend.GatewayOnline = si.Backend.Type == madmin.FS
+	si.Backend.Type = madmin.Gateway
+	return si, errs
+}
+
+// panfsObjects implements gateway for MinIO and S3 compatible object storage servers.
+type panfsObjects struct {
+	minio.ObjectLayer
+}
+
+func (n *panfsObjects) IsTaggingSupported() bool {
+	return true
+}

--- a/cmd/gateway/panfs/gateway-panfs.go
+++ b/cmd/gateway/panfs/gateway-panfs.go
@@ -87,7 +87,7 @@ func (g *PANFS) Name() string {
 // NewGatewayLayer returns panfs gatewaylayer.
 func (g *PANFS) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	var err error
-	newObject, err := minio.NewPANFSObjectLayer(g.path)
+	newObject, err := minio.NewPANFSObjectLayer(minio.GlobalContext, g.path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gateway/panfs/gateway-panfs.go
+++ b/cmd/gateway/panfs/gateway-panfs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/minio/cli"
+	"github.com/minio/madmin-go"
 	minio "github.com/minio/minio/cmd"
 )
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
-	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/arn"
 	"github.com/minio/minio/internal/auth"
@@ -169,7 +168,7 @@ func (sys *IAMSys) initStore(objAPI ObjectLayer, etcdClient *etcd.Client) {
 
 	if etcdClient == nil {
 		if globalIsGateway {
-			if globalGatewayName == NASBackendGateway {
+			if globalGatewayName == NASBackendGateway || globalGatewayName == PANFSBackendGateway {
 				sys.store = &IAMStoreSys{newIAMObjectStore(objAPI, sys.usersSysType)}
 			} else {
 				sys.store = &IAMStoreSys{newIAMDummyStore(sys.usersSysType)}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/arn"
 	"github.com/minio/minio/internal/auth"

--- a/cmd/panfs-metadata.go
+++ b/cmd/panfs-metadata.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	pathutil "path"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/minio/minio/internal/amztime"
+	xhttp "github.com/minio/minio/internal/http"
+	"github.com/minio/minio/internal/lock"
+	"github.com/minio/minio/internal/logger"
+	"github.com/minio/pkg/mimedb"
+)
+
+// FS format, and object metadata.
+const (
+	// fs.json object metadata.
+	panfsMetaJSONFile = "panfs.json"
+)
+
+// FS metadata constants.
+const (
+	// FS backend meta 1.0.0 version.
+	panfsMetaVersion100 = "1.0.0"
+
+	// FS backend meta 1.0.1 version.
+	panfsMetaVersion101 = "1.0.1"
+
+	// FS backend meta 1.0.2
+	// Removed the fields "Format" and "MinIO" from panfsMeta as they were unused. Added "Checksum" field - to be used in future for bit-rot protection.
+	panfsMetaVersion = "1.0.2"
+
+	// Add more constants here.
+)
+
+// PANFSChecksumInfoV1 - carries checksums of individual blocks on disk.
+type PANFSChecksumInfoV1 struct {
+	Algorithm string
+	Blocksize int64
+	Hashes    [][]byte
+}
+
+// MarshalJSON marshals the PANFSChecksumInfoV1 struct
+func (c PANFSChecksumInfoV1) MarshalJSON() ([]byte, error) {
+	type checksuminfo struct {
+		Algorithm string   `json:"algorithm"`
+		Blocksize int64    `json:"blocksize"`
+		Hashes    []string `json:"hashes"`
+	}
+	var hashes []string
+	for _, h := range c.Hashes {
+		hashes = append(hashes, hex.EncodeToString(h))
+	}
+	info := checksuminfo{
+		Algorithm: c.Algorithm,
+		Hashes:    hashes,
+		Blocksize: c.Blocksize,
+	}
+	return json.Marshal(info)
+}
+
+// UnmarshalJSON unmarshals the given data into the PANFSChecksumInfoV1 struct
+func (c *PANFSChecksumInfoV1) UnmarshalJSON(data []byte) error {
+	type checksuminfo struct {
+		Algorithm string   `json:"algorithm"`
+		Blocksize int64    `json:"blocksize"`
+		Hashes    []string `json:"hashes"`
+	}
+
+	var info checksuminfo
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	err := json.Unmarshal(data, &info)
+	if err != nil {
+		return err
+	}
+	c.Algorithm = info.Algorithm
+	c.Blocksize = info.Blocksize
+	var hashes [][]byte
+	for _, hashStr := range info.Hashes {
+		h, err := hex.DecodeString(hashStr)
+		if err != nil {
+			return err
+		}
+		hashes = append(hashes, h)
+	}
+	c.Hashes = hashes
+	return nil
+}
+
+// A panfsMeta represents a metadata header mapping keys to sets of values.
+type panfsMeta struct {
+	Version string `json:"version"`
+	// checksums of blocks on disk.
+	Checksum PANFSChecksumInfoV1 `json:"checksum,omitempty"`
+	// Metadata map for current object.
+	Meta map[string]string `json:"meta,omitempty"`
+	// parts info for current object - used in encryption.
+	Parts []ObjectPartInfo `json:"parts,omitempty"`
+}
+
+// IsValid - tells if the format is sane by validating the version
+// string and format style.
+func (m panfsMeta) IsValid() bool {
+	return isPANFSMetaValid(m.Version)
+}
+
+// Verifies if the backend format metadata is same by validating
+// the version string.
+func isPANFSMetaValid(version string) bool {
+	return version == panfsMetaVersion || version == panfsMetaVersion100 || version == panfsMetaVersion101
+}
+
+// Converts metadata to object info.
+func (m panfsMeta) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo {
+	if len(m.Meta) == 0 {
+		m.Meta = make(map[string]string)
+	}
+
+	// Guess content-type from the extension if possible.
+	if m.Meta["content-type"] == "" {
+		m.Meta["content-type"] = mimedb.TypeByExtension(pathutil.Ext(object))
+	}
+
+	if HasSuffix(object, SlashSeparator) {
+		m.Meta["etag"] = emptyETag // For directories etag is d41d8cd98f00b204e9800998ecf8427e
+		m.Meta["content-type"] = "application/octet-stream"
+	}
+
+	objInfo := ObjectInfo{
+		Bucket: bucket,
+		Name:   object,
+	}
+
+	// We set file info only if its valid.
+	objInfo.ModTime = timeSentinel
+	if fi != nil {
+		objInfo.ModTime = fi.ModTime()
+		objInfo.Size = fi.Size()
+		if fi.IsDir() {
+			// Directory is always 0 bytes in S3 API, treat it as such.
+			objInfo.Size = 0
+			objInfo.IsDir = fi.IsDir()
+		}
+	}
+
+	objInfo.ETag = extractETag(m.Meta)
+
+	objInfo.ContentType = m.Meta["content-type"]
+	objInfo.ContentEncoding = m.Meta["content-encoding"]
+	if storageClass, ok := m.Meta[xhttp.AmzStorageClass]; ok {
+		objInfo.StorageClass = storageClass
+	} else {
+		objInfo.StorageClass = globalMinioDefaultStorageClass
+	}
+
+	if exp, ok := m.Meta["expires"]; ok {
+		if t, e := amztime.ParseHeader(exp); e == nil {
+			objInfo.Expires = t.UTC()
+		}
+	}
+
+	// Add user tags to the object info
+	objInfo.UserTags = m.Meta[xhttp.AmzObjectTagging]
+
+	// etag/md5Sum has already been extracted. We need to
+	// remove to avoid it from appearing as part of
+	// response headers. e.g, X-Minio-* or X-Amz-*.
+	// Tags have also been extracted, we remove that as well.
+	objInfo.UserDefined = cleanMetadata(m.Meta)
+
+	// All the parts per object.
+	objInfo.Parts = m.Parts
+
+	// Success..
+	return objInfo
+}
+
+func (m *panfsMeta) WriteTo(lk *lock.LockedFile) (n int64, err error) {
+	if err = jsonSave(lk, m); err != nil {
+		return 0, err
+	}
+	fi, err := lk.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
+func (m *panfsMeta) ReadFrom(ctx context.Context, lk *lock.LockedFile) (n int64, err error) {
+	var fsMetaBuf []byte
+	fi, err := lk.Stat()
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return 0, err
+	}
+
+	fsMetaBuf, err = ioutil.ReadAll(io.NewSectionReader(lk, 0, fi.Size()))
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return 0, err
+	}
+
+	if len(fsMetaBuf) == 0 {
+		return 0, io.EOF
+	}
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal(fsMetaBuf, m); err != nil {
+		return 0, err
+	}
+
+	// Verify if the format is valid, return corrupted format
+	// for unrecognized formats.
+	if !isPANFSMetaValid(m.Version) {
+		logger.GetReqInfo(ctx).AppendTags("file", lk.Name())
+		logger.LogIf(ctx, errCorruptedFormat)
+		return 0, errCorruptedFormat
+	}
+
+	// Success.
+	return int64(len(fsMetaBuf)), nil
+}
+
+// newPANFSMeta - initializes new panfsMeta.
+func newPANFSMeta() (fsMeta panfsMeta) {
+	fsMeta = panfsMeta{}
+	fsMeta.Version = panfsMetaVersion
+	return fsMeta
+}

--- a/cmd/panfs-metadata_test.go
+++ b/cmd/panfs-metadata_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// Tests ToObjectInfo function.
+func TestPANFSV1MetadataObjInfo(t *testing.T) {
+	fsMeta := newPANFSMeta()
+	objInfo := fsMeta.ToObjectInfo("testbucket", "testobject", nil)
+	if objInfo.Size != 0 {
+		t.Fatal("Unexpected object info value for Size", objInfo.Size)
+	}
+	if !objInfo.ModTime.Equal(timeSentinel) {
+		t.Fatal("Unexpected object info value for ModTime ", objInfo.ModTime)
+	}
+	if objInfo.IsDir {
+		t.Fatal("Unexpected object info value for IsDir", objInfo.IsDir)
+	}
+	if !objInfo.Expires.IsZero() {
+		t.Fatal("Unexpected object info value for Expires ", objInfo.Expires)
+	}
+}
+
+// TestReadPANFSMetadata - readPANFSMetadata testing with a healthy and faulty disk
+func TestReadPANFSMetadata(t *testing.T) {
+	t.Skip()
+
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+
+	bucketName := "bucket"
+	objectName := "object"
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Unexpected err: ", err)
+	}
+	if _, err := obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{}); err != nil {
+		t.Fatal("Unexpected err: ", err)
+	}
+
+	// Construct the full path of fs.json
+	fsPath := pathJoin(bucketMetaPrefix, bucketName, objectName, "panfs.json")
+	fsPath = pathJoin(fs.fsPath, minioMetaBucket, fsPath)
+
+	rlk, err := fs.rwPool.Open(fsPath)
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+	defer rlk.Close()
+
+	// Regular fs metadata reading, no errors expected
+	fsMeta := panfsMeta{}
+	if _, err = fsMeta.ReadFrom(GlobalContext, rlk.LockedFile); err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+}
+
+// TestWritePANFSMetadata - tests of writePANFSMetadata with healthy disk.
+func TestWritePANFSMetadata(t *testing.T) {
+	t.Skip()
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+
+	bucketName := "bucket"
+	objectName := "object"
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Unexpected err: ", err)
+	}
+	if _, err := obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{}); err != nil {
+		t.Fatal("Unexpected err: ", err)
+	}
+
+	// Construct the full path of panfs.json
+	fsPath := pathJoin(bucketMetaPrefix, bucketName, objectName, "panfs.json")
+	fsPath = pathJoin(fs.fsPath, minioMetaBucket, fsPath)
+
+	rlk, err := fs.rwPool.Open(fsPath)
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+	defer rlk.Close()
+
+	// PANFS metadata reading, no errors expected (healthy disk)
+	fsMeta := panfsMeta{}
+	_, err = fsMeta.ReadFrom(GlobalContext, rlk.LockedFile)
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+	if fsMeta.Version != panfsMetaVersion {
+		t.Fatalf("Unexpected version %s", fsMeta.Version)
+	}
+}
+
+func TestPANFSChecksumV1MarshalJSON(t *testing.T) {
+	var cs PANFSChecksumInfoV1
+
+	testCases := []struct {
+		checksum       PANFSChecksumInfoV1
+		expectedResult string
+	}{
+		{cs, `{"algorithm":"","blocksize":0,"hashes":null}`},
+		{PANFSChecksumInfoV1{Algorithm: "highwayhash", Blocksize: 500}, `{"algorithm":"highwayhash","blocksize":500,"hashes":null}`},
+		{PANFSChecksumInfoV1{Algorithm: "highwayhash", Blocksize: 10, Hashes: [][]byte{[]byte("hello")}}, `{"algorithm":"highwayhash","blocksize":10,"hashes":["68656c6c6f"]}`},
+	}
+
+	for _, testCase := range testCases {
+		data, _ := testCase.checksum.MarshalJSON()
+		if testCase.expectedResult != string(data) {
+			t.Fatalf("expected: %v, got: %v", testCase.expectedResult, string(data))
+		}
+	}
+}
+
+func TestPANFSChecksumV1UnMarshalJSON(t *testing.T) {
+	var cs PANFSChecksumInfoV1
+
+	testCases := []struct {
+		data           []byte
+		expectedResult PANFSChecksumInfoV1
+	}{
+		{[]byte(`{"algorithm":"","blocksize":0,"hashes":null}`), cs},
+		{[]byte(`{"algorithm":"highwayhash","blocksize":500,"hashes":null}`), PANFSChecksumInfoV1{Algorithm: "highwayhash", Blocksize: 500}},
+		{[]byte(`{"algorithm":"highwayhash","blocksize":10,"hashes":["68656c6c6f"]}`), PANFSChecksumInfoV1{Algorithm: "highwayhash", Blocksize: 10, Hashes: [][]byte{[]byte("hello")}}},
+	}
+
+	for _, testCase := range testCases {
+		err := (&cs).UnmarshalJSON(testCase.data)
+		if err != nil {
+			t.Fatal("Unexpected error during checksum unmarshalling ", err)
+		}
+		if !reflect.DeepEqual(testCase.expectedResult, cs) {
+			t.Fatalf("expected: %v, got: %v", testCase.expectedResult, cs)
+		}
+	}
+}

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -1,0 +1,947 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	xioutil "github.com/minio/minio/internal/ioutil"
+	"github.com/minio/minio/internal/logger"
+	"github.com/minio/pkg/trie"
+)
+
+const (
+	panbgAppendsDirName         = "bg-appends"
+	panbgAppendsCleanupInterval = 10 * time.Minute
+)
+
+// Returns EXPORT/.minio.sys/multipart/SHA256/UPLOADID
+func (fs *PANFSObjects) getUploadIDDir(bucket, object, uploadID string) string {
+	return pathJoin(fs.fsPath, minioMetaMultipartBucket, getSHA256Hash([]byte(pathJoin(bucket, object))), uploadID)
+}
+
+// Returns EXPORT/.minio.sys/multipart/SHA256
+func (fs *PANFSObjects) getMultipartSHADir(bucket, object string) string {
+	return pathJoin(fs.fsPath, minioMetaMultipartBucket, getSHA256Hash([]byte(pathJoin(bucket, object))))
+}
+
+// Returns partNumber.etag
+func (fs *PANFSObjects) encodePartFile(partNumber int, etag string, actualSize int64) string {
+	return fmt.Sprintf("%.5d.%s.%d", partNumber, etag, actualSize)
+}
+
+// Returns partNumber and etag
+func (fs *PANFSObjects) decodePartFile(name string) (partNumber int, etag string, actualSize int64, err error) {
+	result := strings.Split(name, ".")
+	if len(result) != 3 {
+		return 0, "", 0, errUnexpected
+	}
+	partNumber, err = strconv.Atoi(result[0])
+	if err != nil {
+		return 0, "", 0, errUnexpected
+	}
+	actualSize, err = strconv.ParseInt(result[2], 10, 64)
+	if err != nil {
+		return 0, "", 0, errUnexpected
+	}
+	return partNumber, result[1], actualSize, nil
+}
+
+// Appends parts to an appendFile sequentially.
+func (fs *PANFSObjects) backgroundAppend(ctx context.Context, bucket, object, uploadID string) {
+	fs.appendFileMapMu.Lock()
+	logger.GetReqInfo(ctx).AppendTags("uploadID", uploadID)
+	file := fs.appendFileMap[uploadID]
+	if file == nil {
+		file = &panfsAppendFile{
+			filePath: pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, panbgAppendsDirName, fmt.Sprintf("%s.%s", uploadID, mustGetUUID())),
+		}
+		fs.appendFileMap[uploadID] = file
+	}
+	fs.appendFileMapMu.Unlock()
+
+	file.Lock()
+	defer file.Unlock()
+
+	// Since we append sequentially nextPartNumber will always be len(file.parts)+1
+	nextPartNumber := len(file.parts) + 1
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+
+	entries, err := readDir(uploadIDDir)
+	if err != nil {
+		logger.GetReqInfo(ctx).AppendTags("uploadIDDir", uploadIDDir)
+		logger.LogIf(ctx, err)
+		return
+	}
+	sort.Strings(entries)
+
+	for _, entry := range entries {
+		if entry == fs.metaJSONFile {
+			continue
+		}
+		partNumber, etag, actualSize, err := fs.decodePartFile(entry)
+		if err != nil {
+			// Skip part files whose name don't match expected format. These could be backend filesystem specific files.
+			continue
+		}
+		if partNumber < nextPartNumber {
+			// Part already appended.
+			continue
+		}
+		if partNumber > nextPartNumber {
+			// Required part number is not yet uploaded.
+			return
+		}
+
+		partPath := pathJoin(uploadIDDir, entry)
+		err = xioutil.AppendFile(file.filePath, partPath, globalFSOSync)
+		if err != nil {
+			reqInfo := logger.GetReqInfo(ctx).AppendTags("partPath", partPath)
+			reqInfo.AppendTags("filepath", file.filePath)
+			logger.LogIf(ctx, err)
+			return
+		}
+
+		file.parts = append(file.parts, PartInfo{PartNumber: partNumber, ETag: etag, ActualSize: actualSize})
+		nextPartNumber++
+	}
+}
+
+// ListMultipartUploads - lists all the uploadIDs for the specified object.
+// We do not support prefix based listing.
+func (fs *PANFSObjects) ListMultipartUploads(ctx context.Context, bucket, object, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, e error) {
+	if err := checkListMultipartArgs(ctx, bucket, object, keyMarker, uploadIDMarker, delimiter, fs); err != nil {
+		return result, toObjectErr(err)
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return result, toObjectErr(err, bucket)
+	}
+
+	result.MaxUploads = maxUploads
+	result.KeyMarker = keyMarker
+	result.Prefix = object
+	result.Delimiter = delimiter
+	result.NextKeyMarker = object
+	result.UploadIDMarker = uploadIDMarker
+
+	uploadIDs, err := readDir(fs.getMultipartSHADir(bucket, object))
+	if err != nil {
+		if err == errFileNotFound {
+			result.IsTruncated = false
+			return result, nil
+		}
+		logger.LogIf(ctx, err)
+		return result, toObjectErr(err)
+	}
+
+	// S3 spec says uploadIDs should be sorted based on initiated time. ModTime of fs.json
+	// is the creation time of the uploadID, hence we will use that.
+	var uploads []MultipartInfo
+	for _, uploadID := range uploadIDs {
+		metaFilePath := pathJoin(fs.getMultipartSHADir(bucket, object), uploadID, fs.metaJSONFile)
+		fi, err := fsStatFile(ctx, metaFilePath)
+		if err != nil {
+			return result, toObjectErr(err, bucket, object)
+		}
+		uploads = append(uploads, MultipartInfo{
+			Object:    object,
+			UploadID:  strings.TrimSuffix(uploadID, SlashSeparator),
+			Initiated: fi.ModTime(),
+		})
+	}
+	sort.Slice(uploads, func(i int, j int) bool {
+		return uploads[i].Initiated.Before(uploads[j].Initiated)
+	})
+
+	uploadIndex := 0
+	if uploadIDMarker != "" {
+		for uploadIndex < len(uploads) {
+			if uploads[uploadIndex].UploadID != uploadIDMarker {
+				uploadIndex++
+				continue
+			}
+			if uploads[uploadIndex].UploadID == uploadIDMarker {
+				uploadIndex++
+				break
+			}
+			uploadIndex++
+		}
+	}
+	for uploadIndex < len(uploads) {
+		result.Uploads = append(result.Uploads, uploads[uploadIndex])
+		result.NextUploadIDMarker = uploads[uploadIndex].UploadID
+		uploadIndex++
+		if len(result.Uploads) == maxUploads {
+			break
+		}
+	}
+
+	result.IsTruncated = uploadIndex < len(uploads)
+
+	if !result.IsTruncated {
+		result.NextKeyMarker = ""
+		result.NextUploadIDMarker = ""
+	}
+
+	return result, nil
+}
+
+// NewMultipartUpload - initialize a new multipart upload, returns a
+// unique id. The unique id returned here is of UUID form, for each
+// subsequent request each UUID is unique.
+//
+// Implements S3 compatible initiate multipart API.
+func (fs *PANFSObjects) NewMultipartUpload(ctx context.Context, bucket, object string, opts ObjectOptions) (*NewMultipartUploadResult, error) {
+	if err := checkNewMultipartArgs(ctx, bucket, object, fs); err != nil {
+		return nil, toObjectErr(err, bucket)
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return nil, toObjectErr(err, bucket)
+	}
+
+	uploadID := mustGetUUID()
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+
+	err := mkdirAll(uploadIDDir, 0o755)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return nil, err
+	}
+
+	// Initialize fs.json values.
+	fsMeta := newFSMetaV1()
+	fsMeta.Meta = opts.UserDefined
+
+	fsMetaBytes, err := json.Marshal(fsMeta)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return nil, err
+	}
+
+	if err = ioutil.WriteFile(pathJoin(uploadIDDir, fs.metaJSONFile), fsMetaBytes, 0o666); err != nil {
+		logger.LogIf(ctx, err)
+		return nil, err
+	}
+	return &NewMultipartUploadResult{UploadID: uploadID}, nil
+}
+
+// CopyObjectPart - similar to PutObjectPart but reads data from an existing
+// object. Internally incoming data is written to '.minio.sys/tmp' location
+// and safely renamed to '.minio.sys/multipart' for reach parts.
+func (fs *PANFSObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject, uploadID string, partID int,
+	startOffset int64, length int64, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (pi PartInfo, e error,
+) {
+	if srcOpts.VersionID != "" && srcOpts.VersionID != nullVersionID {
+		return pi, VersionNotFound{
+			Bucket:    srcBucket,
+			Object:    srcObject,
+			VersionID: srcOpts.VersionID,
+		}
+	}
+
+	if err := checkNewMultipartArgs(ctx, srcBucket, srcObject, fs); err != nil {
+		return pi, toObjectErr(err)
+	}
+
+	partInfo, err := fs.PutObjectPart(ctx, dstBucket, dstObject, uploadID, partID, srcInfo.PutObjReader, dstOpts)
+	if err != nil {
+		return pi, toObjectErr(err, dstBucket, dstObject)
+	}
+
+	return partInfo, nil
+}
+
+// PutObjectPart - reads incoming data until EOF for the part file on
+// an ongoing multipart transaction. Internally incoming data is
+// written to '.minio.sys/tmp' location and safely renamed to
+// '.minio.sys/multipart' for reach parts.
+func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, r *PutObjReader, opts ObjectOptions) (pi PartInfo, e error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return pi, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+
+	data := r.Reader
+	if err := checkPutObjectPartArgs(ctx, bucket, object, fs); err != nil {
+		return pi, toObjectErr(err, bucket)
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return pi, toObjectErr(err, bucket)
+	}
+
+	// Validate input data size and it can never be less than -1.
+	if data.Size() < -1 {
+		logger.LogIf(ctx, errInvalidArgument, logger.Application)
+		return pi, toObjectErr(errInvalidArgument)
+	}
+
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+
+	// Just check if the uploadID exists to avoid copy if it doesn't.
+	_, err := fsStatFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile))
+	if err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return pi, toObjectErr(err, bucket, object)
+	}
+
+	tmpPartPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, uploadID+"."+mustGetUUID()+"."+strconv.Itoa(partID))
+	bytesWritten, err := fsCreateFile(ctx, tmpPartPath, data, data.Size())
+
+	// Delete temporary part in case of failure. If
+	// PutObjectPart succeeds then there would be nothing to
+	// delete in which case we just ignore the error.
+	defer fsRemoveFile(ctx, tmpPartPath)
+
+	if err != nil {
+		return pi, toObjectErr(err, minioMetaTmpBucket, tmpPartPath)
+	}
+
+	// Should return IncompleteBody{} error when reader has fewer
+	// bytes than specified in request header.
+	if bytesWritten < data.Size() {
+		return pi, IncompleteBody{Bucket: bucket, Object: object}
+	}
+
+	etag := r.MD5CurrentHexString()
+
+	if etag == "" {
+		etag = GenETag()
+	}
+
+	partPath := pathJoin(uploadIDDir, fs.encodePartFile(partID, etag, data.ActualSize()))
+
+	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
+	if err = Rename(tmpPartPath, partPath); err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return pi, toObjectErr(err, minioMetaMultipartBucket, partPath)
+	}
+
+	go fs.backgroundAppend(ctx, bucket, object, uploadID)
+
+	fi, err := fsStatFile(ctx, partPath)
+	if err != nil {
+		return pi, toObjectErr(err, minioMetaMultipartBucket, partPath)
+	}
+	return PartInfo{
+		PartNumber:   partID,
+		LastModified: fi.ModTime(),
+		ETag:         etag,
+		Size:         fi.Size(),
+		ActualSize:   data.ActualSize(),
+	}, nil
+}
+
+// GetMultipartInfo returns multipart metadata uploaded during newMultipartUpload, used
+// by callers to verify object states
+// - encrypted
+// - compressed
+func (fs *PANFSObjects) GetMultipartInfo(ctx context.Context, bucket, object, uploadID string, opts ObjectOptions) (MultipartInfo, error) {
+	minfo := MultipartInfo{
+		Bucket:   bucket,
+		Object:   object,
+		UploadID: uploadID,
+	}
+
+	if err := checkListPartsArgs(ctx, bucket, object, fs); err != nil {
+		return minfo, toObjectErr(err)
+	}
+
+	// Check if bucket exists
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return minfo, toObjectErr(err, bucket)
+	}
+
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+	if _, err := fsStatFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile)); err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return minfo, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return minfo, toObjectErr(err, bucket, object)
+	}
+
+	fsMetaBytes, err := xioutil.ReadFile(pathJoin(uploadIDDir, fs.metaJSONFile))
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return minfo, toObjectErr(err, bucket, object)
+	}
+
+	var fsMeta fsMetaV1
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal(fsMetaBytes, &fsMeta); err != nil {
+		return minfo, toObjectErr(err, bucket, object)
+	}
+
+	minfo.UserDefined = fsMeta.Meta
+	return minfo, nil
+}
+
+// ListObjectParts - lists all previously uploaded parts for a given
+// object and uploadID.  Takes additional input of part-number-marker
+// to indicate where the listing should begin from.
+//
+// Implements S3 compatible ListObjectParts API. The resulting
+// ListPartsInfo structure is unmarshalled directly into XML and
+// replied back to the client.
+func (fs *PANFSObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts ObjectOptions) (result ListPartsInfo, e error) {
+	if err := checkListPartsArgs(ctx, bucket, object, fs); err != nil {
+		return result, toObjectErr(err)
+	}
+	result.Bucket = bucket
+	result.Object = object
+	result.UploadID = uploadID
+	result.MaxParts = maxParts
+	result.PartNumberMarker = partNumberMarker
+
+	// Check if bucket exists
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return result, toObjectErr(err, bucket)
+	}
+
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+	if _, err := fsStatFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile)); err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return result, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return result, toObjectErr(err, bucket, object)
+	}
+
+	entries, err := readDir(uploadIDDir)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return result, toObjectErr(err, bucket)
+	}
+
+	partsMap := make(map[int]PartInfo)
+	for _, entry := range entries {
+		if entry == fs.metaJSONFile {
+			continue
+		}
+
+		partNumber, currentEtag, actualSize, derr := fs.decodePartFile(entry)
+		if derr != nil {
+			// Skip part files whose name don't match expected format. These could be backend filesystem specific files.
+			continue
+		}
+
+		entryStat, err := fsStatFile(ctx, pathJoin(uploadIDDir, entry))
+		if err != nil {
+			continue
+		}
+
+		currentMeta := PartInfo{
+			PartNumber:   partNumber,
+			ETag:         currentEtag,
+			ActualSize:   actualSize,
+			Size:         entryStat.Size(),
+			LastModified: entryStat.ModTime(),
+		}
+
+		cachedMeta, ok := partsMap[partNumber]
+		if !ok {
+			partsMap[partNumber] = currentMeta
+			continue
+		}
+
+		if currentMeta.LastModified.After(cachedMeta.LastModified) {
+			partsMap[partNumber] = currentMeta
+		}
+	}
+
+	var parts []PartInfo
+	for _, partInfo := range partsMap {
+		parts = append(parts, partInfo)
+	}
+
+	sort.Slice(parts, func(i int, j int) bool {
+		return parts[i].PartNumber < parts[j].PartNumber
+	})
+
+	i := 0
+	if partNumberMarker != 0 {
+		// If the marker was set, skip the entries till the marker.
+		for _, part := range parts {
+			i++
+			if part.PartNumber == partNumberMarker {
+				break
+			}
+		}
+	}
+
+	partsCount := 0
+	for partsCount < maxParts && i < len(parts) {
+		result.Parts = append(result.Parts, parts[i])
+		i++
+		partsCount++
+	}
+	if i < len(parts) {
+		result.IsTruncated = true
+		if partsCount != 0 {
+			result.NextPartNumberMarker = result.Parts[partsCount-1].PartNumber
+		}
+	}
+
+	rc, _, err := fsOpenFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile), 0)
+	if err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return result, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return result, toObjectErr(err, bucket, object)
+	}
+	defer rc.Close()
+
+	fsMetaBytes, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return result, toObjectErr(err, bucket, object)
+	}
+
+	var fsMeta fsMetaV1
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal(fsMetaBytes, &fsMeta); err != nil {
+		return result, err
+	}
+
+	result.UserDefined = fsMeta.Meta
+	return result, nil
+}
+
+// CompleteMultipartUpload - completes an ongoing multipart
+// transaction after receiving all the parts indicated by the client.
+// Returns an md5sum calculated by concatenating all the individual
+// md5sums of all the parts.
+//
+// Implements S3 compatible Complete multipart API.
+func (fs *PANFSObjects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, parts []CompletePart, opts ObjectOptions) (oi ObjectInfo, e error) {
+	var actualSize int64
+
+	if err := checkCompleteMultipartArgs(ctx, bucket, object, fs); err != nil {
+		return oi, toObjectErr(err)
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return oi, toObjectErr(err, bucket)
+	}
+	defer NSUpdated(bucket, object)
+
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+	// Just check if the uploadID exists to avoid copy if it doesn't.
+	_, err := fsStatFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile))
+	if err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return oi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return oi, toObjectErr(err, bucket, object)
+	}
+
+	// ensure that part ETag is canonicalized to strip off extraneous quotes
+	for i := range parts {
+		parts[i].ETag = canonicalizeETag(parts[i].ETag)
+	}
+
+	fsMeta := fsMetaV1{}
+
+	// Allocate parts similar to incoming slice.
+	fsMeta.Parts = make([]ObjectPartInfo, len(parts))
+
+	entries, err := readDir(uploadIDDir)
+	if err != nil {
+		logger.GetReqInfo(ctx).AppendTags("uploadIDDir", uploadIDDir)
+		logger.LogIf(ctx, err)
+		return oi, err
+	}
+
+	// Create entries trie structure for prefix match
+	entriesTrie := trie.NewTrie()
+	for _, entry := range entries {
+		entriesTrie.Insert(entry)
+	}
+
+	// Save consolidated actual size.
+	var objectActualSize int64
+	// Validate all parts and then commit to disk.
+	for i, part := range parts {
+		partFile := getPartFile(entriesTrie, part.PartNumber, part.ETag)
+		if partFile == "" {
+			return oi, InvalidPart{
+				PartNumber: part.PartNumber,
+				GotETag:    part.ETag,
+			}
+		}
+
+		// Read the actualSize from the pathFileName.
+		subParts := strings.Split(partFile, ".")
+		actualSize, err = strconv.ParseInt(subParts[len(subParts)-1], 10, 64)
+		if err != nil {
+			return oi, InvalidPart{
+				PartNumber: part.PartNumber,
+				GotETag:    part.ETag,
+			}
+		}
+
+		partPath := pathJoin(uploadIDDir, partFile)
+
+		var fi os.FileInfo
+		fi, err = fsStatFile(ctx, partPath)
+		if err != nil {
+			if err == errFileNotFound || err == errFileAccessDenied {
+				return oi, InvalidPart{}
+			}
+			return oi, err
+		}
+
+		fsMeta.Parts[i] = ObjectPartInfo{
+			Number:     part.PartNumber,
+			Size:       fi.Size(),
+			ActualSize: actualSize,
+		}
+
+		// Consolidate the actual size.
+		objectActualSize += actualSize
+
+		if i == len(parts)-1 {
+			break
+		}
+
+		// All parts except the last part has to be atleast 5MB.
+		if !isMinAllowedPartSize(actualSize) {
+			return oi, PartTooSmall{
+				PartNumber: part.PartNumber,
+				PartSize:   actualSize,
+				PartETag:   part.ETag,
+			}
+		}
+	}
+
+	appendFallback := true // In case background-append did not append the required parts.
+	appendFilePath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, "bg-appends", fmt.Sprintf("%s.%s", uploadID, mustGetUUID()))
+
+	// Most of the times appendFile would already be fully appended by now. We call fs.backgroundAppend()
+	// to take care of the following corner case:
+	// 1. The last PutObjectPart triggers go-routine fs.backgroundAppend, this go-routine has not started yet.
+	// 2. Now CompleteMultipartUpload gets called which sees that lastPart is not appended and starts appending
+	//    from the beginning
+	fs.backgroundAppend(ctx, bucket, object, uploadID)
+
+	fs.appendFileMapMu.Lock()
+	file := fs.appendFileMap[uploadID]
+	delete(fs.appendFileMap, uploadID)
+	fs.appendFileMapMu.Unlock()
+
+	if file != nil {
+		file.Lock()
+		defer file.Unlock()
+		// Verify that appendFile has all the parts.
+		if len(file.parts) == len(parts) {
+			for i := range parts {
+				if parts[i].ETag != file.parts[i].ETag {
+					break
+				}
+				if parts[i].PartNumber != file.parts[i].PartNumber {
+					break
+				}
+				if i == len(parts)-1 {
+					appendFilePath = file.filePath
+					appendFallback = false
+				}
+			}
+		}
+	}
+
+	if appendFallback {
+		if file != nil {
+			fsRemoveFile(ctx, file.filePath)
+		}
+		for _, part := range parts {
+			partFile := getPartFile(entriesTrie, part.PartNumber, part.ETag)
+			if partFile == "" {
+				logger.LogIf(ctx, fmt.Errorf("%.5d.%s missing will not proceed",
+					part.PartNumber, part.ETag))
+				return oi, InvalidPart{
+					PartNumber: part.PartNumber,
+					GotETag:    part.ETag,
+				}
+			}
+			if err = xioutil.AppendFile(appendFilePath, pathJoin(uploadIDDir, partFile), globalFSOSync); err != nil {
+				logger.LogIf(ctx, err)
+				return oi, toObjectErr(err)
+			}
+		}
+	}
+
+	// Hold write lock on the object.
+	destLock := fs.NewNSLock(bucket, object)
+	lkctx, err := destLock.GetLock(ctx, globalOperationTimeout)
+	if err != nil {
+		return oi, err
+	}
+	ctx = lkctx.Context()
+	defer destLock.Unlock(lkctx.Cancel)
+
+	bucketMetaDir := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix)
+	fsMetaPath := pathJoin(bucketMetaDir, bucket, object, fs.metaJSONFile)
+	metaFile, err := fs.rwPool.Write(fsMetaPath)
+	var freshFile bool
+	if err != nil {
+		if !errors.Is(err, errFileNotFound) {
+			logger.LogIf(ctx, err)
+			return oi, toObjectErr(err, bucket, object)
+		}
+		metaFile, err = fs.rwPool.Create(fsMetaPath)
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return oi, toObjectErr(err, bucket, object)
+		}
+		freshFile = true
+	}
+	defer metaFile.Close()
+	defer func() {
+		// Remove meta file when CompleteMultipart encounters
+		// any error and it is a fresh file.
+		//
+		// We should preserve the `fs.json` of any
+		// existing object
+		if e != nil && freshFile {
+			tmpDir := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID)
+			fsRemoveMeta(ctx, bucketMetaDir, fsMetaPath, tmpDir)
+		}
+	}()
+
+	// Read saved fs metadata for ongoing multipart.
+	fsMetaBuf, err := xioutil.ReadFile(pathJoin(uploadIDDir, fs.metaJSONFile))
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return oi, toObjectErr(err, bucket, object)
+	}
+	err = json.Unmarshal(fsMetaBuf, &fsMeta)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return oi, toObjectErr(err, bucket, object)
+	}
+	// Save additional metadata.
+	if fsMeta.Meta == nil {
+		fsMeta.Meta = make(map[string]string)
+	}
+
+	fsMeta.Meta["etag"] = opts.UserDefined["etag"]
+	if fsMeta.Meta["etag"] == "" {
+		fsMeta.Meta["etag"] = getCompleteMultipartMD5(parts)
+	}
+
+	// Save consolidated actual size.
+	fsMeta.Meta[ReservedMetadataPrefix+"actual-size"] = strconv.FormatInt(objectActualSize, 10)
+	if _, err = fsMeta.WriteTo(metaFile); err != nil {
+		logger.LogIf(ctx, err)
+		return oi, toObjectErr(err, bucket, object)
+	}
+
+	err = fsRenameFile(ctx, appendFilePath, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return oi, toObjectErr(err, bucket, object)
+	}
+
+	// Purge multipart folders
+	{
+		fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, mustGetUUID())
+		defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
+
+		Rename(uploadIDDir, fsTmpObjPath)
+
+		// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
+		fsRemoveDir(ctx, fs.getMultipartSHADir(bucket, object))
+	}
+
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		return oi, toObjectErr(err, bucket, object)
+	}
+
+	return fsMeta.ToObjectInfo(bucket, object, fi), nil
+}
+
+// AbortMultipartUpload - aborts an ongoing multipart operation
+// signified by the input uploadID. This is an atomic operation
+// doesn't require clients to initiate multiple such requests.
+//
+// All parts are purged from all disks and reference to the uploadID
+// would be removed from the system, rollback is not possible on this
+// operation.
+//
+// Implements S3 compatible Abort multipart API, slight difference is
+// that this is an atomic idempotent operation. Subsequent calls have
+// no affect and further requests to the same uploadID would not be
+// honored.
+func (fs *PANFSObjects) AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string, opts ObjectOptions) error {
+	if err := checkAbortMultipartArgs(ctx, bucket, object, fs); err != nil {
+		return err
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	fs.appendFileMapMu.Lock()
+	// Remove file in tmp folder
+	file := fs.appendFileMap[uploadID]
+	if file != nil {
+		fsRemoveFile(ctx, file.filePath)
+	}
+	delete(fs.appendFileMap, uploadID)
+	fs.appendFileMapMu.Unlock()
+
+	uploadIDDir := fs.getUploadIDDir(bucket, object, uploadID)
+	// Just check if the uploadID exists to avoid copy if it doesn't.
+	_, err := fsStatFile(ctx, pathJoin(uploadIDDir, fs.metaJSONFile))
+	if err != nil {
+		if err == errFileNotFound || err == errFileAccessDenied {
+			return InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
+		}
+		return toObjectErr(err, bucket, object)
+	}
+
+	// Purge multipart folders
+	{
+		fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, mustGetUUID())
+		defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
+
+		Rename(uploadIDDir, fsTmpObjPath)
+
+		// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
+		fsRemoveDir(ctx, fs.getMultipartSHADir(bucket, object))
+	}
+
+	return nil
+}
+
+// Return all uploads IDs with full path of each upload-id directory.
+// Do not return an error as this is a lazy operation
+func (fs *PANFSObjects) getAllUploadIDs(ctx context.Context) (result map[string]string) {
+	result = make(map[string]string)
+
+	entries, err := readDir(pathJoin(fs.fsPath, minioMetaMultipartBucket))
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		uploadIDs, err := readDir(pathJoin(fs.fsPath, minioMetaMultipartBucket, entry))
+		if err != nil {
+			continue
+		}
+		// Remove the trailing slash separator
+		for i := range uploadIDs {
+			uploadID := strings.TrimSuffix(uploadIDs[i], SlashSeparator)
+			result[uploadID] = pathJoin(fs.fsPath, minioMetaMultipartBucket, entry, uploadID)
+		}
+	}
+	return
+}
+
+// Removes multipart uploads if any older than `expiry` duration
+// on all buckets for every `cleanupInterval`, this function is
+// blocking and should be run in a go-routine.
+func (fs *PANFSObjects) cleanupStaleUploads(ctx context.Context) {
+	expiryUploadsTimer := time.NewTimer(globalAPIConfig.getStaleUploadsCleanupInterval())
+	defer expiryUploadsTimer.Stop()
+
+	bgAppendTmpCleaner := time.NewTimer(panbgAppendsCleanupInterval)
+	defer bgAppendTmpCleaner.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-bgAppendTmpCleaner.C:
+			foundUploadIDs := fs.getAllUploadIDs(ctx)
+
+			// Remove background append map from the memory
+			fs.appendFileMapMu.Lock()
+			for uploadID := range fs.appendFileMap {
+				_, ok := foundUploadIDs[uploadID]
+				if !ok {
+					delete(fs.appendFileMap, uploadID)
+				}
+			}
+			fs.appendFileMapMu.Unlock()
+
+			// Remove background appends file from the disk
+			bgAppendsDir := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, panbgAppendsDirName)
+			entries, err := readDir(bgAppendsDir)
+			if err != nil {
+				break
+			}
+			for _, entry := range entries {
+				uploadID := strings.Split(entry, ".")[0]
+				_, ok := foundUploadIDs[uploadID]
+				if !ok {
+					fsRemoveFile(ctx, pathJoin(bgAppendsDir, entry))
+				}
+			}
+
+			bgAppendTmpCleaner.Reset(panbgAppendsCleanupInterval)
+		case <-expiryUploadsTimer.C:
+			expiry := globalAPIConfig.getStaleUploadsExpiry()
+			now := time.Now()
+
+			uploadIDs := fs.getAllUploadIDs(ctx)
+
+			for uploadID, path := range uploadIDs {
+				fi, err := fsStatDir(ctx, path)
+				if err != nil {
+					continue
+				}
+				if now.Sub(fi.ModTime()) > expiry {
+					fsRemoveAll(ctx, path)
+					// Remove upload ID parent directory if empty
+					fsRemoveDir(ctx, filepath.Base(path))
+
+					// Remove uploadID from the append file map and its corresponding temporary file
+					fs.appendFileMapMu.Lock()
+					bgAppend, ok := fs.appendFileMap[uploadID]
+					if ok {
+						_ = fsRemoveFile(ctx, bgAppend.filePath)
+						delete(fs.appendFileMap, uploadID)
+					}
+					fs.appendFileMapMu.Unlock()
+				}
+			}
+
+			// Reset for the next interval
+			expiryUploadsTimer.Reset(globalAPIConfig.getStaleUploadsCleanupInterval())
+		}
+	}
+}

--- a/cmd/panfs-multipart_test.go
+++ b/cmd/panfs-multipart_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/minio/minio/internal/config/api"
+)
+
+// Tests cleanup multipart uploads for filesystem backend.
+func TestPANFSCleanupMultipartUploadsInRoutine(t *testing.T) {
+	t.Skip()
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+
+	bucketName := "bucket"
+	objectName := "object"
+
+	// Create a context we can cancel.
+	ctx, cancel := context.WithCancel(GlobalContext)
+	obj.MakeBucketWithLocation(ctx, bucketName, MakeBucketOptions{})
+
+	res, err := obj.NewMultipartUpload(ctx, bucketName, objectName, ObjectOptions{})
+	if err != nil {
+		t.Fatal("Unexpected err: ", err)
+	}
+
+	globalAPIConfig.init(api.Config{
+		ListQuorum:                  "optimal",
+		StaleUploadsExpiry:          time.Millisecond,
+		StaleUploadsCleanupInterval: time.Millisecond,
+	}, obj.SetDriveCounts())
+
+	defer func() {
+		globalAPIConfig.init(api.Config{
+			ListQuorum: "optimal",
+		}, obj.SetDriveCounts())
+	}()
+
+	var cleanupWg sync.WaitGroup
+	cleanupWg.Add(1)
+	go func() {
+		defer cleanupWg.Done()
+		fs.cleanupStaleUploads(ctx)
+	}()
+
+	// Wait for 100ms such that - we have given enough time for
+	// cleanup routine to kick in. Flaky on slow systems...
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	cleanupWg.Wait()
+
+	// Check if upload id was already purged.
+	if err = obj.AbortMultipartUpload(GlobalContext, bucketName, objectName, res.UploadID, ObjectOptions{}); err != nil {
+		if _, ok := err.(InvalidUploadID); !ok {
+			t.Fatal("Unexpected err: ", err)
+		}
+	} else {
+		t.Error("Item was not cleaned up.")
+	}
+}
+
+// TestNewPANFMultipartUploadFaultyDisk - test NewMultipartUpload with faulty disks
+func TestNewPANFMultipartUploadFaultyDisk(t *testing.T) {
+	t.Skip()
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+	obj := initFSObjects(disk, t)
+
+	fs := obj.(*PANFSObjects)
+	bucketName := "bucket"
+	objectName := "object"
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	// Test with disk removed.
+	os.RemoveAll(disk)
+	if _, err := fs.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error ", err)
+		}
+	}
+}
+
+// TestPANFSPutObjectPartFaultyDisk - test PutObjectPart with faulty disks
+func TestPANFSPutObjectPartFaultyDisk(t *testing.T) {
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+	obj := initFSObjects(disk, t)
+
+	bucketName := "bucket"
+	objectName := "object"
+	data := []byte("12345")
+	dataLen := int64(len(data))
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	md5Hex := getMD5Hash(data)
+	sha256sum := ""
+
+	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(newDisk)
+	obj = initFSObjects(newDisk, t)
+	if _, err = obj.PutObjectPart(GlobalContext, bucketName, objectName, res.UploadID, 1, mustGetPutObjReader(t, bytes.NewReader(data), dataLen, md5Hex, sha256sum), ObjectOptions{}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error ", err)
+		}
+	}
+}
+
+// TestPANFSCompleteMultipartUploadFaultyDisk - test CompleteMultipartUpload with faulty disks
+func TestPANFSCompleteMultipartUploadFaultyDisk(t *testing.T) {
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+	obj := initFSObjects(disk, t)
+
+	bucketName := "bucket"
+	objectName := "object"
+	data := []byte("12345")
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	md5Hex := getMD5Hash(data)
+
+	parts := []CompletePart{{PartNumber: 1, ETag: md5Hex}}
+	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(newDisk)
+	obj = initFSObjects(newDisk, t)
+	if _, err := obj.CompleteMultipartUpload(GlobalContext, bucketName, objectName, res.UploadID, parts, ObjectOptions{}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error ", err)
+		}
+	}
+}
+
+// TestPANFSCompleteMultipartUpload - test CompleteMultipartUpload
+func TestPANFSCompleteMultipartUpload(t *testing.T) {
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+	obj := initFSObjects(disk, t)
+
+	bucketName := "bucket"
+	objectName := "object"
+	data := []byte("12345")
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	md5Hex := getMD5Hash(data)
+
+	if _, err := obj.PutObjectPart(GlobalContext, bucketName, objectName, res.UploadID, 1, mustGetPutObjReader(t, bytes.NewReader(data), 5, md5Hex, ""), ObjectOptions{}); err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	parts := []CompletePart{{PartNumber: 1, ETag: md5Hex}}
+	if _, err := obj.CompleteMultipartUpload(GlobalContext, bucketName, objectName, res.UploadID, parts, ObjectOptions{}); err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+}
+
+// TestPANFSAbortMultipartUpload - test CompleteMultipartUpload
+func TestPANFSAbortMultipartUpload(t *testing.T) {
+	if runtime.GOOS == globalWindowsOSName {
+		// Concurrent AbortMultipartUpload() fails on windows
+		t.Skip()
+	}
+
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+	obj := initFSObjects(disk, t)
+
+	bucketName := "bucket"
+	objectName := "object"
+	data := []byte("12345")
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	md5Hex := getMD5Hash(data)
+
+	opts := ObjectOptions{}
+	if _, err := obj.PutObjectPart(GlobalContext, bucketName, objectName, res.UploadID, 1, mustGetPutObjReader(t, bytes.NewReader(data), 5, md5Hex, ""), opts); err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+	if err := obj.AbortMultipartUpload(GlobalContext, bucketName, objectName, res.UploadID, opts); err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+}
+
+// TestPANFSListMultipartUploadsFaultyDisk - test ListMultipartUploads with faulty disks
+func TestPANFSListMultipartUploadsFaultyDisk(t *testing.T) {
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+
+	bucketName := "bucket"
+	objectName := "object"
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Cannot create bucket, err: ", err)
+	}
+
+	_, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
+	if err != nil {
+		t.Fatal("Unexpected error ", err)
+	}
+
+	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(newDisk)
+	obj = initFSObjects(newDisk, t)
+	if _, err := obj.ListMultipartUploads(GlobalContext, bucketName, objectName, "", "", "", 1000); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error ", err)
+		}
+	}
+}

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/tags"
 	"github.com/minio/minio/internal/color"
@@ -117,8 +118,7 @@ func initMetaVolumePANFS(fsPath, fsUUID string) error {
 }
 
 // NewPANFSObjectLayer - initialize new panfs object layer.
-func NewPANFSObjectLayer(fsPath string) (ObjectLayer, error) {
-	ctx := GlobalContext
+func NewPANFSObjectLayer(ctx context.Context, fsPath string) (ObjectLayer, error) {
 	if fsPath == "" {
 		return nil, errInvalidArgument
 	}

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1,0 +1,1499 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+	"github.com/minio/minio-go/v7/pkg/tags"
+	"github.com/minio/minio/internal/color"
+	"github.com/minio/minio/internal/config"
+	xhttp "github.com/minio/minio/internal/http"
+	xioutil "github.com/minio/minio/internal/ioutil"
+	"github.com/minio/minio/internal/lock"
+	"github.com/minio/minio/internal/logger"
+	"github.com/minio/minio/internal/mountinfo"
+	"github.com/minio/pkg/bucket/policy"
+	"github.com/minio/pkg/mimedb"
+)
+
+// Default etag is used for pre-existing objects.
+var PANdefaultEtag = "00000000000000000000000000000000-2"
+
+// PANFSObjects - Implements panfs object layer.
+type PANFSObjects struct {
+	GatewayUnsupported
+
+	// Path to be exported over S3 API.
+	fsPath string
+	// meta json filename, varies by fs / cache backend.
+	metaJSONFile string
+	// Unique value to be used for all
+	// temporary transactions.
+	fsUUID string
+
+	// This value shouldn't be touched, once initialized.
+	fsFormatRlk *lock.RLockedFile // Is a read lock on `format.json`.
+
+	// FS rw pool.
+	rwPool *fsIOPool
+
+	// ListObjects pool management.
+	listPool *TreeWalkPool
+
+	diskMount bool
+
+	appendFileMap   map[string]*panfsAppendFile
+	appendFileMapMu sync.Mutex
+
+	// To manage the appendRoutine go-routines
+	nsMutex *nsLockMap
+}
+
+// Represents the background append file.
+type panfsAppendFile struct {
+	sync.Mutex
+	parts    []PartInfo // List of parts appended.
+	filePath string     // Absolute path of the file in the temp location.
+}
+
+// Initializes meta volume on all the fs path.
+func initMetaVolumePANFS(fsPath, fsUUID string) error {
+	// This happens for the first time, but keep this here since this
+	// is the only place where it can be made less expensive
+	// optimizing all other calls. Create minio meta volume,
+	// if it doesn't exist yet.
+	metaBucketPath := pathJoin(fsPath, minioMetaBucket)
+
+	if err := os.MkdirAll(metaBucketPath, 0o777); err != nil {
+		return err
+	}
+
+	metaTmpPath := pathJoin(fsPath, minioMetaTmpBucket, fsUUID)
+	if err := os.MkdirAll(metaTmpPath, 0o777); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(pathJoin(metaTmpPath, bgAppendsDirName), 0o777); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(pathJoin(fsPath, dataUsageBucket), 0o777); err != nil {
+		return err
+	}
+
+	metaMultipartPath := pathJoin(fsPath, minioMetaMultipartBucket)
+	return os.MkdirAll(metaMultipartPath, 0o777)
+}
+
+// NewPANFSObjectLayer - initialize new panfs object layer.
+func NewPANFSObjectLayer(fsPath string) (ObjectLayer, error) {
+	ctx := GlobalContext
+	if fsPath == "" {
+		return nil, errInvalidArgument
+	}
+
+	var err error
+	if fsPath, err = getValidPath(fsPath); err != nil {
+		if err == errMinDiskSize {
+			return nil, config.ErrUnableToWriteInBackend(err).Hint(err.Error())
+		}
+
+		// Show a descriptive error with a hint about how to fix it.
+		var username string
+		if u, err := user.Current(); err == nil {
+			username = u.Username
+		} else {
+			username = "<your-username>"
+		}
+		hint := fmt.Sprintf("Use 'sudo chown -R %s %s && sudo chmod u+rxw %s' to provide sufficient permissions.", username, fsPath, fsPath)
+		return nil, config.ErrUnableToWriteInBackend(err).Hint(hint)
+	}
+
+	// Assign a new UUID for FS minio mode. Each server instance
+	// gets its own UUID for temporary file transaction.
+	fsUUID := mustGetUUID()
+
+	// Initialize meta volume, if volume already exists ignores it.
+	if err = initMetaVolumePANFS(fsPath, fsUUID); err != nil {
+		return nil, err
+	}
+
+	// Initialize `format.json`, this function also returns.
+	rlk, err := initFormatFS(ctx, fsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize fs objects.
+	fs := &PANFSObjects{
+		fsPath:       fsPath,
+		metaJSONFile: panfsMetaJSONFile,
+		fsUUID:       fsUUID,
+		rwPool: &fsIOPool{
+			readersMap: make(map[string]*lock.RLockedFile),
+		},
+		nsMutex:       newNSLock(false),
+		listPool:      NewTreeWalkPool(globalLookupTimeout),
+		appendFileMap: make(map[string]*panfsAppendFile),
+		diskMount:     mountinfo.IsLikelyMountPoint(fsPath),
+	}
+
+	// Once the filesystem has initialized hold the read lock for
+	// the life time of the server. This is done to ensure that under
+	// shared backend mode for FS, remote servers do not migrate
+	// or cause changes on backend format.
+	fs.fsFormatRlk = rlk
+
+	go fs.cleanupStaleUploads(ctx)
+	go intDataUpdateTracker.start(ctx, fsPath)
+
+	// Return successfully initialized object layer.
+	return fs, nil
+}
+
+// NewNSLock - initialize a new namespace RWLocker instance.
+func (fs *PANFSObjects) NewNSLock(bucket string, objects ...string) RWLocker {
+	// lockers are explicitly 'nil' for FS mode since there are only local lockers
+	return fs.nsMutex.NewNSLock(nil, bucket, objects...)
+}
+
+// SetDriveCounts no-op
+func (fs *PANFSObjects) SetDriveCounts() []int {
+	return nil
+}
+
+// Shutdown - should be called when process shuts down.
+func (fs *PANFSObjects) Shutdown(ctx context.Context) error {
+	fs.fsFormatRlk.Close()
+
+	// Cleanup and delete tmp uuid.
+	return fsRemoveAll(ctx, pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID))
+}
+
+// BackendInfo - returns backend information
+func (fs *PANFSObjects) BackendInfo() madmin.BackendInfo {
+	return madmin.BackendInfo{Type: madmin.FS}
+}
+
+// LocalStorageInfo - returns underlying storage statistics.
+func (fs *PANFSObjects) LocalStorageInfo(ctx context.Context) (StorageInfo, []error) {
+	return fs.StorageInfo(ctx)
+}
+
+// StorageInfo - returns underlying storage statistics.
+func (fs *PANFSObjects) StorageInfo(ctx context.Context) (StorageInfo, []error) {
+	di, err := getDiskInfo(fs.fsPath)
+	if err != nil {
+		return StorageInfo{}, []error{err}
+	}
+	storageInfo := StorageInfo{
+		Disks: []madmin.Disk{
+			{
+				State:          madmin.DriveStateOk,
+				TotalSpace:     di.Total,
+				UsedSpace:      di.Used,
+				AvailableSpace: di.Free,
+				DrivePath:      fs.fsPath,
+			},
+		},
+	}
+	storageInfo.Backend = fs.BackendInfo()
+	return storageInfo, nil
+}
+
+// NSScanner returns data usage stats of the current FS deployment
+func (fs *PANFSObjects) NSScanner(ctx context.Context, bf *bloomFilter, updates chan<- DataUsageInfo, wantCycle uint32, _ madmin.HealScanMode) error {
+	defer close(updates)
+	// Load bucket totals
+	var totalCache dataUsageCache
+	err := totalCache.load(ctx, fs, dataUsageCacheName)
+	if err != nil {
+		return err
+	}
+	totalCache.Info.Name = dataUsageRoot
+	buckets, err := fs.ListBuckets(ctx, BucketOptions{})
+	if err != nil {
+		return err
+	}
+	if len(buckets) == 0 {
+		totalCache.keepBuckets(buckets)
+		updates <- totalCache.dui(dataUsageRoot, buckets)
+		return nil
+	}
+	for i, b := range buckets {
+		if isReservedOrInvalidBucket(b.Name, false) {
+			// Delete bucket...
+			buckets = append(buckets[:i], buckets[i+1:]...)
+		}
+	}
+
+	totalCache.Info.BloomFilter = bf.bytes()
+
+	// Clear totals.
+	var root dataUsageEntry
+	if r := totalCache.root(); r != nil {
+		root.Children = r.Children
+	}
+	totalCache.replace(dataUsageRoot, "", root)
+
+	// Delete all buckets that does not exist anymore.
+	totalCache.keepBuckets(buckets)
+
+	for _, b := range buckets {
+		// Load bucket cache.
+		var bCache dataUsageCache
+		err := bCache.load(ctx, fs, path.Join(b.Name, dataUsageCacheName))
+		if err != nil {
+			return err
+		}
+		if bCache.Info.Name == "" {
+			bCache.Info.Name = b.Name
+		}
+		bCache.Info.BloomFilter = totalCache.Info.BloomFilter
+		bCache.Info.NextCycle = wantCycle
+		upds := make(chan dataUsageEntry, 1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for update := range upds {
+				totalCache.replace(b.Name, dataUsageRoot, update)
+				if intDataUpdateTracker.debug {
+					logger.Info(color.Green("NSScanner:")+" Got update: %v", len(totalCache.Cache))
+				}
+				cloned := totalCache.clone()
+				updates <- cloned.dui(dataUsageRoot, buckets)
+			}
+		}()
+		bCache.Info.updates = upds
+		cache, err := fs.scanBucket(ctx, b.Name, bCache)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		logger.LogIf(ctx, err)
+		cache.Info.BloomFilter = nil
+		wg.Wait()
+
+		if cache.root() == nil {
+			if intDataUpdateTracker.debug {
+				logger.Info(color.Green("NSScanner:") + " No root added. Adding empty")
+			}
+			cache.replace(cache.Info.Name, dataUsageRoot, dataUsageEntry{})
+		}
+		if cache.Info.LastUpdate.After(bCache.Info.LastUpdate) {
+			if intDataUpdateTracker.debug {
+				logger.Info(color.Green("NSScanner:")+" Saving bucket %q cache with %d entries", b.Name, len(cache.Cache))
+			}
+			logger.LogIf(ctx, cache.save(ctx, fs, path.Join(b.Name, dataUsageCacheName)))
+		}
+		// Merge, save and send update.
+		// We do it even if unchanged.
+		cl := cache.clone()
+		entry := cl.flatten(*cl.root())
+		totalCache.replace(cl.Info.Name, dataUsageRoot, entry)
+		if intDataUpdateTracker.debug {
+			logger.Info(color.Green("NSScanner:")+" Saving totals cache with %d entries", len(totalCache.Cache))
+		}
+		totalCache.Info.LastUpdate = time.Now()
+		logger.LogIf(ctx, totalCache.save(ctx, fs, dataUsageCacheName))
+		cloned := totalCache.clone()
+		updates <- cloned.dui(dataUsageRoot, buckets)
+
+	}
+
+	return nil
+}
+
+// scanBucket scans a single bucket in FS mode.
+// The updated cache for the bucket is returned.
+// A partially updated bucket may be returned.
+func (fs *PANFSObjects) scanBucket(ctx context.Context, bucket string, cache dataUsageCache) (dataUsageCache, error) {
+	defer close(cache.Info.updates)
+	defer globalScannerMetrics.log(scannerMetricScanBucketDisk, fs.fsPath, bucket)()
+
+	// Get bucket policy
+	// Check if the current bucket has a configured lifecycle policy
+	lc, err := globalLifecycleSys.Get(bucket)
+	if err == nil && lc.HasActiveRules("", true) {
+		if intDataUpdateTracker.debug {
+			logger.Info(color.Green("scanBucket:") + " lifecycle: Active rules found")
+		}
+		cache.Info.lifeCycle = lc
+	}
+
+	// Load bucket info.
+	cache, err = scanDataFolder(ctx, -1, -1, fs.fsPath, cache, func(item scannerItem) (sizeSummary, error) {
+		bucket, object := item.bucket, item.objectPath()
+		stopFn := globalScannerMetrics.log(scannerMetricScanObject, fs.fsPath, PathJoin(item.bucket, item.objectPath()))
+		defer stopFn()
+
+		var fsMetaBytes []byte
+		done := globalScannerMetrics.timeSize(scannerMetricReadMetadata)
+		defer func() {
+			if done != nil {
+				done(len(fsMetaBytes))
+			}
+		}()
+		fsMetaBytes, err := xioutil.ReadFile(pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile))
+		if err != nil && !osIsNotExist(err) {
+			if intDataUpdateTracker.debug {
+				logger.Info(color.Green("scanBucket:")+" object return unexpected error: %v/%v: %w", item.bucket, item.objectPath(), err)
+			}
+			return sizeSummary{}, errSkipFile
+		}
+
+		fsMeta := newPANFSMeta()
+		metaOk := false
+		if len(fsMetaBytes) > 0 {
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			if err = json.Unmarshal(fsMetaBytes, &fsMeta); err == nil {
+				metaOk = true
+			}
+		}
+		if !metaOk {
+			fsMeta = fs.defaultFsJSON(object)
+		}
+
+		// Stat the file.
+		fi, fiErr := os.Stat(item.Path)
+		if fiErr != nil {
+			if intDataUpdateTracker.debug {
+				logger.Info(color.Green("scanBucket:")+" object path missing: %v: %w", item.Path, fiErr)
+			}
+			return sizeSummary{}, errSkipFile
+		}
+		done(len(fsMetaBytes))
+		done = nil
+
+		// FS has no "all versions". Increment the counter, though
+		globalScannerMetrics.incNoTime(scannerMetricApplyAll)
+
+		oi := fsMeta.ToObjectInfo(bucket, object, fi)
+		doneVer := globalScannerMetrics.time(scannerMetricApplyVersion)
+		sz := item.applyActions(ctx, fs, oi, &sizeSummary{})
+		doneVer()
+		if sz >= 0 {
+			return sizeSummary{totalSize: sz, versions: 1}, nil
+		}
+
+		return sizeSummary{totalSize: fi.Size(), versions: 1}, nil
+	}, 0)
+
+	return cache, err
+}
+
+// Bucket operations
+
+// getBucketDir - will convert incoming bucket names to
+// corresponding valid bucket names on the backend in a platform
+// compatible way for all operating systems.
+func (fs *PANFSObjects) getBucketDir(ctx context.Context, bucket string) (string, error) {
+	if bucket == "" || bucket == "." || bucket == ".." {
+		return "", errVolumeNotFound
+	}
+	bucketDir := pathJoin(fs.fsPath, bucket)
+	return bucketDir, nil
+}
+
+func (fs *PANFSObjects) statBucketDir(ctx context.Context, bucket string) (os.FileInfo, error) {
+	bucketDir, err := fs.getBucketDir(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+	st, err := fsStatVolume(ctx, bucketDir)
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+// MakeBucketWithLocation - create a new bucket, returns if it already exists.
+func (fs *PANFSObjects) MakeBucketWithLocation(ctx context.Context, bucket string, opts MakeBucketOptions) error {
+	if opts.LockEnabled || opts.VersioningEnabled {
+		return NotImplemented{}
+	}
+
+	// Verify if bucket is valid.
+	if s3utils.CheckValidBucketNameStrict(bucket) != nil {
+		return BucketNameInvalid{Bucket: bucket}
+	}
+
+	defer NSUpdated(bucket, slashSeparator)
+
+	bucketDir, err := fs.getBucketDir(ctx, bucket)
+	if err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	if err = fsMkdir(ctx, bucketDir); err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	meta := newBucketMetadata(bucket)
+	if err := meta.Save(ctx, fs); err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	globalBucketMetadataSys.Set(bucket, meta)
+
+	return nil
+}
+
+// GetBucketPolicy - only needed for FS in NAS mode
+func (fs *PANFSObjects) GetBucketPolicy(ctx context.Context, bucket string) (*policy.Policy, error) {
+	meta, err := loadBucketMetadata(ctx, fs, bucket)
+	if err != nil {
+		return nil, BucketPolicyNotFound{Bucket: bucket}
+	}
+	if meta.policyConfig == nil {
+		return nil, BucketPolicyNotFound{Bucket: bucket}
+	}
+	return meta.policyConfig, nil
+}
+
+// SetBucketPolicy - only needed for FS in NAS mode
+func (fs *PANFSObjects) SetBucketPolicy(ctx context.Context, bucket string, p *policy.Policy) error {
+	meta, err := loadBucketMetadata(ctx, fs, bucket)
+	if err != nil {
+		return err
+	}
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	configData, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	meta.PolicyConfigJSON = configData
+
+	return meta.Save(ctx, fs)
+}
+
+// DeleteBucketPolicy - only needed for FS in NAS mode
+func (fs *PANFSObjects) DeleteBucketPolicy(ctx context.Context, bucket string) error {
+	meta, err := loadBucketMetadata(ctx, fs, bucket)
+	if err != nil {
+		return err
+	}
+	meta.PolicyConfigJSON = nil
+	return meta.Save(ctx, fs)
+}
+
+// GetBucketInfo - fetch bucket metadata info.
+func (fs *PANFSObjects) GetBucketInfo(ctx context.Context, bucket string, opts BucketOptions) (bi BucketInfo, e error) {
+	st, err := fs.statBucketDir(ctx, bucket)
+	if err != nil {
+		return bi, toObjectErr(err, bucket)
+	}
+
+	createdTime := st.ModTime()
+	meta, err := globalBucketMetadataSys.Get(bucket)
+	if err == nil {
+		createdTime = meta.Created
+	}
+
+	return BucketInfo{
+		Name:    bucket,
+		Created: createdTime,
+	}, nil
+}
+
+// ListBuckets - list all s3 compatible buckets (directories) at fsPath.
+func (fs *PANFSObjects) ListBuckets(ctx context.Context, opts BucketOptions) ([]BucketInfo, error) {
+	if err := checkPathLength(fs.fsPath); err != nil {
+		logger.LogIf(ctx, err)
+		return nil, err
+	}
+
+	entries, err := readDirWithOpts(fs.fsPath, readDirOpts{count: -1, followDirSymlink: true})
+	if err != nil {
+		logger.LogIf(ctx, errDiskNotFound)
+		return nil, toObjectErr(errDiskNotFound)
+	}
+
+	bucketInfos := make([]BucketInfo, 0, len(entries))
+	for _, entry := range entries {
+		// Ignore all reserved bucket names and invalid bucket names.
+		if isReservedOrInvalidBucket(entry, false) {
+			continue
+		}
+		var fi os.FileInfo
+		fi, err = fsStatVolume(ctx, pathJoin(fs.fsPath, entry))
+		// There seems like no practical reason to check for errors
+		// at this point, if there are indeed errors we can simply
+		// just ignore such buckets and list only those which
+		// return proper Stat information instead.
+		if err != nil {
+			// Ignore any errors returned here.
+			continue
+		}
+		created := fi.ModTime()
+		meta, err := globalBucketMetadataSys.Get(fi.Name())
+		if err == nil {
+			created = meta.Created
+		}
+
+		bucketInfos = append(bucketInfos, BucketInfo{
+			Name:    fi.Name(),
+			Created: created,
+		})
+	}
+
+	// Sort bucket infos by bucket name.
+	sort.Slice(bucketInfos, func(i, j int) bool {
+		return bucketInfos[i].Name < bucketInfos[j].Name
+	})
+
+	// Succes.
+	return bucketInfos, nil
+}
+
+// DeleteBucket - delete a bucket and all the metadata associated
+// with the bucket including pending multipart, object metadata.
+func (fs *PANFSObjects) DeleteBucket(ctx context.Context, bucket string, opts DeleteBucketOptions) error {
+	defer NSUpdated(bucket, slashSeparator)
+
+	bucketDir, err := fs.getBucketDir(ctx, bucket)
+	if err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	if !opts.Force {
+		// Attempt to delete regular bucket.
+		if err = fsRemoveDir(ctx, bucketDir); err != nil {
+			return toObjectErr(err, bucket)
+		}
+	} else {
+		tmpBucketPath := pathJoin(fs.fsPath, minioMetaTmpBucket, bucket+"."+mustGetUUID())
+		if err = Rename(bucketDir, tmpBucketPath); err != nil {
+			return toObjectErr(err, bucket)
+		}
+
+		go func() {
+			fsRemoveAll(ctx, tmpBucketPath) // ignore returned error if any.
+		}()
+	}
+
+	// Cleanup all the bucket metadata.
+	minioMetadataBucketDir := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket)
+	if err = fsRemoveAll(ctx, minioMetadataBucketDir); err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	// Delete all bucket metadata.
+	deleteBucketMetadata(ctx, fs, bucket)
+
+	return nil
+}
+
+// Object Operations
+
+// CopyObject - copy object source object to destination object.
+// if source object and destination object are same we only
+// update metadata.
+func (fs *PANFSObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject string, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (oi ObjectInfo, err error) {
+	if srcOpts.VersionID != "" && srcOpts.VersionID != nullVersionID {
+		return oi, VersionNotFound{
+			Bucket:    srcBucket,
+			Object:    srcObject,
+			VersionID: srcOpts.VersionID,
+		}
+	}
+
+	cpSrcDstSame := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
+	defer NSUpdated(dstBucket, dstObject)
+
+	if !cpSrcDstSame {
+		objectDWLock := fs.NewNSLock(dstBucket, dstObject)
+		lkctx, err := objectDWLock.GetLock(ctx, globalOperationTimeout)
+		if err != nil {
+			return oi, err
+		}
+		ctx = lkctx.Context()
+		defer objectDWLock.Unlock(lkctx.Cancel)
+	}
+
+	if _, err := fs.statBucketDir(ctx, srcBucket); err != nil {
+		return oi, toObjectErr(err, srcBucket)
+	}
+
+	if cpSrcDstSame && srcInfo.metadataOnly {
+		fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, srcBucket, srcObject, fs.metaJSONFile)
+		wlk, err := fs.rwPool.Write(fsMetaPath)
+		if err != nil {
+			wlk, err = fs.rwPool.Create(fsMetaPath)
+			if err != nil {
+				logger.LogIf(ctx, err)
+				return oi, toObjectErr(err, srcBucket, srcObject)
+			}
+		}
+		// This close will allow for locks to be synchronized on `fs.json`.
+		defer wlk.Close()
+
+		// Save objects' metadata in `fs.json`.
+		fsMeta := newPANFSMeta()
+		if _, err = fsMeta.ReadFrom(ctx, wlk); err != nil {
+			// For any error to read fsMeta, set default ETag and proceed.
+			fsMeta = fs.defaultFsJSON(srcObject)
+		}
+
+		fsMeta.Meta = cloneMSS(srcInfo.UserDefined)
+		fsMeta.Meta["etag"] = srcInfo.ETag
+		if _, err = fsMeta.WriteTo(wlk); err != nil {
+			return oi, toObjectErr(err, srcBucket, srcObject)
+		}
+
+		fsObjectPath := pathJoin(fs.fsPath, srcBucket, srcObject)
+
+		// Update object modtime
+		err = fsTouch(ctx, fsObjectPath)
+		if err != nil {
+			return oi, toObjectErr(err, srcBucket, srcObject)
+		}
+		// Stat the file to get object info
+		fi, err := fsStatFile(ctx, fsObjectPath)
+		if err != nil {
+			return oi, toObjectErr(err, srcBucket, srcObject)
+		}
+
+		// Return the new object info.
+		return fsMeta.ToObjectInfo(srcBucket, srcObject, fi), nil
+	}
+
+	if err := checkPutObjectArgs(ctx, dstBucket, dstObject, fs); err != nil {
+		return ObjectInfo{}, err
+	}
+
+	objInfo, err := fs.putObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, ObjectOptions{ServerSideEncryption: dstOpts.ServerSideEncryption, UserDefined: srcInfo.UserDefined})
+	if err != nil {
+		return oi, toObjectErr(err, dstBucket, dstObject)
+	}
+
+	return objInfo, nil
+}
+
+// GetObjectNInfo - returns object info and a reader for object
+// content.
+func (fs *PANFSObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return nil, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+	if err = checkGetObjArgs(ctx, bucket, object); err != nil {
+		return nil, err
+	}
+
+	if _, err = fs.statBucketDir(ctx, bucket); err != nil {
+		return nil, toObjectErr(err, bucket)
+	}
+
+	nsUnlocker := func() {}
+
+	if lockType != noLock {
+		// Lock the object before reading.
+		lock := fs.NewNSLock(bucket, object)
+		switch lockType {
+		case writeLock:
+			lkctx, err := lock.GetLock(ctx, globalOperationTimeout)
+			if err != nil {
+				return nil, err
+			}
+			ctx = lkctx.Context()
+			nsUnlocker = func() { lock.Unlock(lkctx.Cancel) }
+		case readLock:
+			lkctx, err := lock.GetRLock(ctx, globalOperationTimeout)
+			if err != nil {
+				return nil, err
+			}
+			ctx = lkctx.Context()
+			nsUnlocker = func() { lock.RUnlock(lkctx.Cancel) }
+		}
+	}
+
+	// Otherwise we get the object info
+	var objInfo ObjectInfo
+	if objInfo, err = fs.getObjectInfo(ctx, bucket, object); err != nil {
+		nsUnlocker()
+		return nil, toObjectErr(err, bucket, object)
+	}
+	// For a directory, we need to return a reader that returns no bytes.
+	if HasSuffix(object, SlashSeparator) {
+		// The lock taken above is released when
+		// objReader.Close() is called by the caller.
+		return NewGetObjectReaderFromReader(bytes.NewBuffer(nil), objInfo, opts, nsUnlocker)
+	}
+	// Take a rwPool lock for NFS gateway type deployment
+	rwPoolUnlocker := func() {}
+	if bucket != minioMetaBucket && lockType != noLock {
+		fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+		_, err = fs.rwPool.Open(fsMetaPath)
+		if err != nil && err != errFileNotFound {
+			logger.LogIf(ctx, err)
+			nsUnlocker()
+			return nil, toObjectErr(err, bucket, object)
+		}
+		// Need to clean up lock after getObject is
+		// completed.
+		rwPoolUnlocker = func() { fs.rwPool.Close(fsMetaPath) }
+	}
+
+	objReaderFn, off, length, err := NewGetObjectReader(rs, objInfo, opts)
+	if err != nil {
+		rwPoolUnlocker()
+		nsUnlocker()
+		return nil, err
+	}
+
+	// Read the object, doesn't exist returns an s3 compatible error.
+	fsObjPath := pathJoin(fs.fsPath, bucket, object)
+	readCloser, size, err := fsOpenFile(ctx, fsObjPath, off)
+	if err != nil {
+		rwPoolUnlocker()
+		nsUnlocker()
+		return nil, toObjectErr(err, bucket, object)
+	}
+
+	closeFn := func() {
+		readCloser.Close()
+	}
+	reader := io.LimitReader(readCloser, length)
+
+	// Check if range is valid
+	if off > size || off+length > size {
+		err = InvalidRange{off, length, size}
+		logger.LogIf(ctx, err, logger.Application)
+		closeFn()
+		rwPoolUnlocker()
+		nsUnlocker()
+		return nil, err
+	}
+
+	return objReaderFn(reader, h, closeFn, rwPoolUnlocker, nsUnlocker)
+}
+
+// Create a new fs.json file, if the existing one is corrupt. Should happen very rarely.
+func (fs *PANFSObjects) createFsJSON(object, fsMetaPath string) error {
+	fsMeta := newPANFSMeta()
+	fsMeta.Meta = map[string]string{
+		"etag":         GenETag(),
+		"content-type": mimedb.TypeByExtension(path.Ext(object)),
+	}
+	wlk, werr := fs.rwPool.Create(fsMetaPath)
+	if werr == nil {
+		_, err := fsMeta.WriteTo(wlk)
+		wlk.Close()
+		return err
+	}
+	return werr
+}
+
+// Used to return default etag values when a pre-existing object's meta data is queried.
+func (fs *PANFSObjects) defaultFsJSON(object string) panfsMeta {
+	fsMeta := newPANFSMeta()
+	fsMeta.Meta = map[string]string{
+		"etag":         PANdefaultEtag,
+		"content-type": mimedb.TypeByExtension(path.Ext(object)),
+	}
+	return fsMeta
+}
+
+func (fs *PANFSObjects) getObjectInfoNoFSLock(ctx context.Context, bucket, object string) (oi ObjectInfo, e error) {
+	fsMeta := panfsMeta{}
+	if HasSuffix(object, SlashSeparator) {
+		fi, err := fsStatDir(ctx, pathJoin(fs.fsPath, bucket, object))
+		if err != nil {
+			return oi, err
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	}
+
+	if !globalCLIContext.StrictS3Compat {
+		// Stat the file to get file size.
+		fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+		if err != nil {
+			return oi, err
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	}
+
+	fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+	// Read `fs.json` to perhaps contend with
+	// parallel Put() operations.
+
+	rc, _, err := fsOpenFile(ctx, fsMetaPath, 0)
+	if err == nil {
+		fsMetaBuf, rerr := ioutil.ReadAll(rc)
+		rc.Close()
+		if rerr == nil {
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			if rerr = json.Unmarshal(fsMetaBuf, &fsMeta); rerr != nil {
+				// For any error to read fsMeta, set default ETag and proceed.
+				fsMeta = fs.defaultFsJSON(object)
+			}
+		} else {
+			// For any error to read fsMeta, set default ETag and proceed.
+			fsMeta = fs.defaultFsJSON(object)
+		}
+	}
+
+	// Return a default etag and content-type based on the object's extension.
+	if err == errFileNotFound {
+		fsMeta = fs.defaultFsJSON(object)
+	}
+
+	// Ignore if `fs.json` is not available, this is true for pre-existing data.
+	if err != nil && err != errFileNotFound {
+		logger.LogIf(ctx, err)
+		return oi, err
+	}
+
+	// Stat the file to get file size.
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		return oi, err
+	}
+
+	return fsMeta.ToObjectInfo(bucket, object, fi), nil
+}
+
+// getObjectInfo - wrapper for reading object metadata and constructs ObjectInfo.
+func (fs *PANFSObjects) getObjectInfo(ctx context.Context, bucket, object string) (oi ObjectInfo, e error) {
+	if strings.HasSuffix(object, SlashSeparator) && !fs.isObjectDir(bucket, object) {
+		return oi, errFileNotFound
+	}
+
+	fsMeta := panfsMeta{}
+	if HasSuffix(object, SlashSeparator) {
+		fi, err := fsStatDir(ctx, pathJoin(fs.fsPath, bucket, object))
+		if err != nil {
+			return oi, err
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	}
+
+	fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+	// Read `fs.json` to perhaps contend with
+	// parallel Put() operations.
+
+	rlk, err := fs.rwPool.Open(fsMetaPath)
+	if err == nil {
+		// Read from fs metadata only if it exists.
+		_, rerr := fsMeta.ReadFrom(ctx, rlk.LockedFile)
+		fs.rwPool.Close(fsMetaPath)
+		if rerr != nil {
+			// For any error to read fsMeta, set default ETag and proceed.
+			fsMeta = fs.defaultFsJSON(object)
+		}
+	}
+
+	// Return a default etag and content-type based on the object's extension.
+	if err == errFileNotFound {
+		fsMeta = fs.defaultFsJSON(object)
+	}
+
+	// Ignore if `fs.json` is not available, this is true for pre-existing data.
+	if err != nil && err != errFileNotFound {
+		logger.LogIf(ctx, err)
+		return oi, err
+	}
+
+	// Stat the file to get file size.
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		return oi, err
+	}
+
+	return fsMeta.ToObjectInfo(bucket, object, fi), nil
+}
+
+// getObjectInfoWithLock - reads object metadata and replies back ObjectInfo.
+func (fs *PANFSObjects) getObjectInfoWithLock(ctx context.Context, bucket, object string) (oi ObjectInfo, err error) {
+	// Lock the object before reading.
+	lk := fs.NewNSLock(bucket, object)
+	lkctx, err := lk.GetRLock(ctx, globalOperationTimeout)
+	if err != nil {
+		return oi, err
+	}
+	ctx = lkctx.Context()
+	defer lk.RUnlock(lkctx.Cancel)
+
+	if err := checkGetObjArgs(ctx, bucket, object); err != nil {
+		return oi, err
+	}
+
+	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
+		return oi, err
+	}
+
+	if strings.HasSuffix(object, SlashSeparator) && !fs.isObjectDir(bucket, object) {
+		return oi, errFileNotFound
+	}
+
+	return fs.getObjectInfo(ctx, bucket, object)
+}
+
+// GetObjectInfo - reads object metadata and replies back ObjectInfo.
+func (fs *PANFSObjects) GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (oi ObjectInfo, e error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return oi, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+
+	oi, err := fs.getObjectInfoWithLock(ctx, bucket, object)
+	if err == errCorruptedFormat || err == io.EOF {
+		lk := fs.NewNSLock(bucket, object)
+		lkctx, err := lk.GetLock(ctx, globalOperationTimeout)
+		if err != nil {
+			return oi, toObjectErr(err, bucket, object)
+		}
+
+		fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+		err = fs.createFsJSON(object, fsMetaPath)
+		lk.Unlock(lkctx.Cancel)
+		if err != nil {
+			return oi, toObjectErr(err, bucket, object)
+		}
+
+		oi, err = fs.getObjectInfoWithLock(ctx, bucket, object)
+		return oi, toObjectErr(err, bucket, object)
+	}
+	return oi, toObjectErr(err, bucket, object)
+}
+
+// PutObject - creates an object upon reading from the input stream
+// until EOF, writes data directly to configured filesystem path.
+// Additionally writes `fs.json` which carries the necessary metadata
+// for future object operations.
+func (fs *PANFSObjects) PutObject(ctx context.Context, bucket string, object string, r *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	if opts.Versioned {
+		return objInfo, NotImplemented{}
+	}
+
+	if err := checkPutObjectArgs(ctx, bucket, object, fs); err != nil {
+		return ObjectInfo{}, err
+	}
+
+	defer NSUpdated(bucket, object)
+
+	// Lock the object.
+	lk := fs.NewNSLock(bucket, object)
+	lkctx, err := lk.GetLock(ctx, globalOperationTimeout)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return objInfo, err
+	}
+	ctx = lkctx.Context()
+	defer lk.Unlock(lkctx.Cancel)
+
+	return fs.putObject(ctx, bucket, object, r, opts)
+}
+
+// putObject - wrapper for PutObject
+func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object string, r *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
+	data := r.Reader
+
+	// No metadata is set, allocate a new one.
+	meta := cloneMSS(opts.UserDefined)
+	var err error
+
+	// Validate if bucket name is valid and exists.
+	if _, err = fs.statBucketDir(ctx, bucket); err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket)
+	}
+
+	fsMeta := newPANFSMeta()
+	fsMeta.Meta = meta
+
+	// This is a special case with size as '0' and object ends
+	// with a slash separator, we treat it like a valid operation
+	// and return success.
+	if isObjectDir(object, data.Size()) {
+		if err = mkdirAll(pathJoin(fs.fsPath, bucket, object), 0o777); err != nil {
+			logger.LogIf(ctx, err)
+			return ObjectInfo{}, toObjectErr(err, bucket, object)
+		}
+		var fi os.FileInfo
+		if fi, err = fsStatDir(ctx, pathJoin(fs.fsPath, bucket, object)); err != nil {
+			return ObjectInfo{}, toObjectErr(err, bucket, object)
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	}
+
+	// Validate input data size and it can never be less than zero.
+	if data.Size() < -1 {
+		logger.LogIf(ctx, errInvalidArgument, logger.Application)
+		return ObjectInfo{}, errInvalidArgument
+	}
+
+	var wlk *lock.LockedFile
+	if bucket != minioMetaBucket {
+		bucketMetaDir := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix)
+		fsMetaPath := pathJoin(bucketMetaDir, bucket, object, fs.metaJSONFile)
+		wlk, err = fs.rwPool.Write(fsMetaPath)
+		var freshFile bool
+		if err != nil {
+			wlk, err = fs.rwPool.Create(fsMetaPath)
+			if err != nil {
+				logger.LogIf(ctx, err)
+				return ObjectInfo{}, toObjectErr(err, bucket, object)
+			}
+			freshFile = true
+		}
+		// This close will allow for locks to be synchronized on `fs.json`.
+		defer wlk.Close()
+		defer func() {
+			// Remove meta file when PutObject encounters
+			// any error and it is a fresh file.
+			//
+			// We should preserve the `fs.json` of any
+			// existing object
+			if retErr != nil && freshFile {
+				tmpDir := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID)
+				fsRemoveMeta(ctx, bucketMetaDir, fsMetaPath, tmpDir)
+			}
+		}()
+	}
+
+	// Uploaded object will first be written to the temporary location which will eventually
+	// be renamed to the actual location. It is first written to the temporary location
+	// so that cleaning it up will be easy if the server goes down.
+	tempObj := mustGetUUID()
+
+	fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
+	bytesWritten, err := fsCreateFile(ctx, fsTmpObjPath, data, data.Size())
+
+	// Delete the temporary object in the case of a
+	// failure. If PutObject succeeds, then there would be
+	// nothing to delete.
+	defer fsRemoveFile(ctx, fsTmpObjPath)
+
+	if err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+	fsMeta.Meta["etag"] = r.MD5CurrentHexString()
+
+	// Should return IncompleteBody{} error when reader has fewer
+	// bytes than specified in request header.
+	if bytesWritten < data.Size() {
+		return ObjectInfo{}, IncompleteBody{Bucket: bucket, Object: object}
+	}
+
+	// Entire object was written to the temp location, now it's safe to rename it to the actual location.
+	fsNSObjPath := pathJoin(fs.fsPath, bucket, object)
+	if err = fsRenameFile(ctx, fsTmpObjPath, fsNSObjPath); err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	if bucket != minioMetaBucket {
+		// Write FS metadata after a successful namespace operation.
+		if _, err = fsMeta.WriteTo(wlk); err != nil {
+			return ObjectInfo{}, toObjectErr(err, bucket, object)
+		}
+	}
+
+	// Stat the file to fetch timestamp, size.
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	// Success.
+	return fsMeta.ToObjectInfo(bucket, object, fi), nil
+}
+
+// DeleteObjects - deletes an object from a bucket, this operation is destructive
+// and there are no rollbacks supported.
+func (fs *PANFSObjects) DeleteObjects(ctx context.Context, bucket string, objects []ObjectToDelete, opts ObjectOptions) ([]DeletedObject, []error) {
+	errs := make([]error, len(objects))
+	dobjects := make([]DeletedObject, len(objects))
+	for idx, object := range objects {
+		if object.VersionID != "" {
+			errs[idx] = VersionNotFound{
+				Bucket:    bucket,
+				Object:    object.ObjectName,
+				VersionID: object.VersionID,
+			}
+			continue
+		}
+		_, errs[idx] = fs.DeleteObject(ctx, bucket, object.ObjectName, opts)
+		if errs[idx] == nil || isErrObjectNotFound(errs[idx]) {
+			dobjects[idx] = DeletedObject{
+				ObjectName: object.ObjectName,
+			}
+			errs[idx] = nil
+		}
+	}
+	return dobjects, errs
+}
+
+// DeleteObject - deletes an object from a bucket, this operation is destructive
+// and there are no rollbacks supported.
+func (fs *PANFSObjects) DeleteObject(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return objInfo, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+
+	defer NSUpdated(bucket, object)
+
+	// Acquire a write lock before deleting the object.
+	lk := fs.NewNSLock(bucket, object)
+	lkctx, err := lk.GetLock(ctx, globalOperationTimeout)
+	if err != nil {
+		return objInfo, err
+	}
+	ctx = lkctx.Context()
+	defer lk.Unlock(lkctx.Cancel)
+
+	if err = checkDelObjArgs(ctx, bucket, object); err != nil {
+		return objInfo, err
+	}
+
+	if _, err = fs.statBucketDir(ctx, bucket); err != nil {
+		return objInfo, toObjectErr(err, bucket)
+	}
+
+	var rwlk *lock.LockedFile
+
+	minioMetaBucketDir := pathJoin(fs.fsPath, minioMetaBucket)
+	fsMetaPath := pathJoin(minioMetaBucketDir, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+	if bucket != minioMetaBucket {
+		rwlk, err = fs.rwPool.Write(fsMetaPath)
+		if err != nil && err != errFileNotFound {
+			logger.LogIf(ctx, err)
+			return objInfo, toObjectErr(err, bucket, object)
+		}
+	}
+
+	// Delete the object.
+	if err = fsDeleteFile(ctx, pathJoin(fs.fsPath, bucket), pathJoin(fs.fsPath, bucket, object)); err != nil {
+		if rwlk != nil {
+			rwlk.Close()
+		}
+		return objInfo, toObjectErr(err, bucket, object)
+	}
+
+	// Close fsMetaPath before deletion
+	if rwlk != nil {
+		rwlk.Close()
+	}
+
+	if bucket != minioMetaBucket {
+		// Delete the metadata object.
+		err = fsDeleteFile(ctx, minioMetaBucketDir, fsMetaPath)
+		if err != nil && err != errFileNotFound {
+			return objInfo, toObjectErr(err, bucket, object)
+		}
+	}
+	return ObjectInfo{Bucket: bucket, Name: object}, nil
+}
+
+func (fs *PANFSObjects) isLeafDir(bucket string, leafPath string) bool {
+	return fs.isObjectDir(bucket, leafPath)
+}
+
+func (fs *PANFSObjects) isLeaf(bucket string, leafPath string) bool {
+	return !strings.HasSuffix(leafPath, slashSeparator)
+}
+
+// Returns function "listDir" of the type listDirFunc.
+// isLeaf - is used by listDir function to check if an entry
+// is a leaf or non-leaf entry.
+func (fs *PANFSObjects) listDirFactory() ListDirFunc {
+	// listDir - lists all the entries at a given prefix and given entry in the prefix.
+	listDir := func(bucket, prefixDir, prefixEntry string) (emptyDir bool, entries []string, delayIsLeaf bool) {
+		var err error
+		entries, err = readDir(pathJoin(fs.fsPath, bucket, prefixDir))
+		if err != nil && err != errFileNotFound {
+			logger.LogIf(GlobalContext, err)
+			return false, nil, false
+		}
+		if len(entries) == 0 {
+			return true, nil, false
+		}
+		entries, delayIsLeaf = filterListEntries(bucket, prefixDir, entries, prefixEntry, fs.isLeaf)
+		return false, entries, delayIsLeaf
+	}
+
+	// Return list factory instance.
+	return listDir
+}
+
+// isObjectDir returns true if the specified bucket & prefix exists
+// and the prefix represents an empty directory. An S3 empty directory
+// is also an empty directory in the FS backend.
+func (fs *PANFSObjects) isObjectDir(bucket, prefix string) bool {
+	entries, err := readDirN(pathJoin(fs.fsPath, bucket, prefix), 1)
+	if err != nil {
+		return false
+	}
+	return len(entries) == 0
+}
+
+// ListObjectVersions not implemented for FS mode.
+func (fs *PANFSObjects) ListObjectVersions(ctx context.Context, bucket, prefix, marker, versionMarker, delimiter string, maxKeys int) (loi ListObjectVersionsInfo, e error) {
+	return loi, NotImplemented{}
+}
+
+// ListObjects - list all objects at prefix upto maxKeys., optionally delimited by '/'. Maintains the list pool
+// state for future re-entrant list requests.
+func (fs *PANFSObjects) ListObjects(ctx context.Context, bucket, prefix, marker, delimiter string, maxKeys int) (loi ListObjectsInfo, err error) {
+	// listObjects may in rare cases not be able to find any valid results.
+	// Therefore, it cannot set a NextMarker.
+	// In that case we retry the operation, but we add a
+	// max limit, so we never end up in an infinite loop.
+	tries := 50
+	for {
+		loi, err = listObjects(ctx, fs, bucket, prefix, marker, delimiter, maxKeys, fs.listPool,
+			fs.listDirFactory(), fs.isLeaf, fs.isLeafDir, fs.getObjectInfoNoFSLock, fs.getObjectInfoNoFSLock)
+		if err != nil {
+			return loi, err
+		}
+		if !loi.IsTruncated || loi.NextMarker != "" || tries == 0 {
+			return loi, nil
+		}
+		tries--
+	}
+}
+
+// GetObjectTags - get object tags from an existing object
+func (fs *PANFSObjects) GetObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (*tags.Tags, error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return nil, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+	oi, err := fs.GetObjectInfo(ctx, bucket, object, ObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return tags.ParseObjectTags(oi.UserTags)
+}
+
+// PutObjectTags - replace or add tags to an existing object
+func (fs *PANFSObjects) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
+	if opts.VersionID != "" && opts.VersionID != nullVersionID {
+		return ObjectInfo{}, VersionNotFound{
+			Bucket:    bucket,
+			Object:    object,
+			VersionID: opts.VersionID,
+		}
+	}
+
+	fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
+	fsMeta := panfsMeta{}
+	wlk, err := fs.rwPool.Write(fsMetaPath)
+	if err != nil {
+		wlk, err = fs.rwPool.Create(fsMetaPath)
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return ObjectInfo{}, toObjectErr(err, bucket, object)
+		}
+	}
+	// This close will allow for locks to be synchronized on `fs.json`.
+	defer wlk.Close()
+
+	// Read objects' metadata in `fs.json`.
+	if _, err = fsMeta.ReadFrom(ctx, wlk); err != nil {
+		// For any error to read fsMeta, set default ETag and proceed.
+		fsMeta = fs.defaultFsJSON(object)
+	}
+
+	// clean fsMeta.Meta of tag key, before updating the new tags
+	delete(fsMeta.Meta, xhttp.AmzObjectTagging)
+
+	// Do not update for empty tags
+	if tags != "" {
+		fsMeta.Meta[xhttp.AmzObjectTagging] = tags
+	}
+
+	if _, err = fsMeta.WriteTo(wlk); err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	// Stat the file to get file size.
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+
+	return fsMeta.ToObjectInfo(bucket, object, fi), nil
+}
+
+// DeleteObjectTags - delete object tags from an existing object
+func (fs *PANFSObjects) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	return fs.PutObjectTags(ctx, bucket, object, "", opts)
+}
+
+// HealFormat - no-op for fs, Valid only for Erasure.
+func (fs *PANFSObjects) HealFormat(ctx context.Context, dryRun bool) (madmin.HealResultItem, error) {
+	return madmin.HealResultItem{}, NotImplemented{}
+}
+
+// HealObject - no-op for fs. Valid only for Erasure.
+func (fs *PANFSObjects) HealObject(ctx context.Context, bucket, object, versionID string, opts madmin.HealOpts) (
+	res madmin.HealResultItem, err error,
+) {
+	return res, NotImplemented{}
+}
+
+// HealBucket - no-op for fs, Valid only for Erasure.
+func (fs *PANFSObjects) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem,
+	error,
+) {
+	return madmin.HealResultItem{}, NotImplemented{}
+}
+
+// Walk a bucket, optionally prefix recursively, until we have returned
+// all the content to objectInfo channel, it is callers responsibility
+// to allocate a receive channel for ObjectInfo, upon any unhandled
+// error walker returns error. Optionally if context.Done() is received
+// then Walk() stops the walker.
+func (fs *PANFSObjects) Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo, opts ObjectOptions) error {
+	return fsWalk(ctx, fs, bucket, prefix, fs.listDirFactory(), fs.isLeaf, fs.isLeafDir, results, fs.getObjectInfoNoFSLock, fs.getObjectInfoNoFSLock)
+}
+
+// HealObjects - no-op for fs. Valid only for Erasure.
+func (fs *PANFSObjects) HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) (e error) {
+	logger.LogIf(ctx, NotImplemented{})
+	return NotImplemented{}
+}
+
+// GetMetrics - no op
+func (fs *PANFSObjects) GetMetrics(ctx context.Context) (*BackendMetrics, error) {
+	logger.LogIf(ctx, NotImplemented{})
+	return &BackendMetrics{}, NotImplemented{}
+}
+
+// ListObjectsV2 lists all blobs in bucket filtered by prefix
+func (fs *PANFSObjects) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (result ListObjectsV2Info, err error) {
+	marker := continuationToken
+	if marker == "" {
+		marker = startAfter
+	}
+
+	loi, err := fs.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+	if err != nil {
+		return result, err
+	}
+
+	listObjectsV2Info := ListObjectsV2Info{
+		IsTruncated:           loi.IsTruncated,
+		ContinuationToken:     continuationToken,
+		NextContinuationToken: loi.NextMarker,
+		Objects:               loi.Objects,
+		Prefixes:              loi.Prefixes,
+	}
+	return listObjectsV2Info, err
+}
+
+// IsNotificationSupported returns whether bucket notification is applicable for this layer.
+func (fs *PANFSObjects) IsNotificationSupported() bool {
+	return true
+}
+
+// IsListenSupported returns whether listen bucket notification is applicable for this layer.
+func (fs *PANFSObjects) IsListenSupported() bool {
+	return true
+}
+
+// IsEncryptionSupported returns whether server side encryption is implemented for this layer.
+func (fs *PANFSObjects) IsEncryptionSupported() bool {
+	return true
+}
+
+// IsCompressionSupported returns whether compression is applicable for this layer.
+func (fs *PANFSObjects) IsCompressionSupported() bool {
+	return true
+}
+
+// IsTaggingSupported returns true, object tagging is supported in fs object layer.
+func (fs *PANFSObjects) IsTaggingSupported() bool {
+	return true
+}
+
+// Health returns health of the object layer
+func (fs *PANFSObjects) Health(ctx context.Context, opts HealthOptions) HealthResult {
+	if _, err := os.Stat(fs.fsPath); err != nil {
+		return HealthResult{}
+	}
+	return HealthResult{
+		Healthy: newObjectLayerFn() != nil,
+	}
+}
+
+// ReadHealth returns "read" health of the object layer
+func (fs *PANFSObjects) ReadHealth(ctx context.Context) bool {
+	_, err := os.Stat(fs.fsPath)
+	return err == nil
+}
+
+// TransitionObject - transition object content to target tier.
+func (fs *PANFSObjects) TransitionObject(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+	return NotImplemented{}
+}
+
+// RestoreTransitionedObject - restore transitioned object content locally on this cluster.
+func (fs *PANFSObjects) RestoreTransitionedObject(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+	return NotImplemented{}
+}
+
+// GetRawData returns raw file data to the callback.
+// Errors are ignored, only errors from the callback are returned.
+// For now only direct file paths are supported.
+func (fs *PANFSObjects) GetRawData(ctx context.Context, volume, file string, fn func(r io.Reader, host string, disk string, filename string, size int64, modtime time.Time, isDir bool) error) error {
+	f, err := os.Open(filepath.Join(fs.fsPath, volume, file))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil || st.IsDir() {
+		return nil
+	}
+	return fn(f, "fs", fs.fsUUID, file, st.Size(), st.ModTime(), st.IsDir())
+}

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,17 +30,19 @@ import (
 // TestNewPANFS - tests initialization of all input disks
 // and constructs a valid `PANFS` object layer.
 func TestNewPANFS(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// Do not attempt to create this path, the test validates
 	// so that NewPANFSObjectLayer initializes non existing paths
 	// and successfully returns initialized object layer.
 	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer os.RemoveAll(disk)
 
-	_, err := NewPANFSObjectLayer("")
+	_, err := NewPANFSObjectLayer(ctx, "")
 	if err != errInvalidArgument {
 		t.Errorf("Expecting error invalid argument, got %s", err)
 	}
-	_, err = NewPANFSObjectLayer(disk)
+	_, err = NewPANFSObjectLayer(ctx, disk)
 	if err != nil {
 		errMsg := "Unable to recognize backend format, Drive is not in FS format."
 		if err.Error() == errMsg {

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNewPANFS - tests initialization of all input disks
+// and constructs a valid `PANFS` object layer.
+func TestNewPANFS(t *testing.T) {
+	// Do not attempt to create this path, the test validates
+	// so that NewPANFSObjectLayer initializes non existing paths
+	// and successfully returns initialized object layer.
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	_, err := NewPANFSObjectLayer("")
+	if err != errInvalidArgument {
+		t.Errorf("Expecting error invalid argument, got %s", err)
+	}
+	_, err = NewPANFSObjectLayer(disk)
+	if err != nil {
+		errMsg := "Unable to recognize backend format, Drive is not in FS format."
+		if err.Error() == errMsg {
+			t.Errorf("Expecting %s, got %s", errMsg, err)
+		}
+	}
+}
+
+// TestFSShutdown - initialize a new FS object layer then calls
+// Shutdown to check returned results
+func TestPANFSShutdown(t *testing.T) {
+	t.Skip()
+
+	bucketName := "testbucket"
+	objectName := "object"
+	// Create and return an panfsObject with its path in the disk
+	prepareTest := func() (*PANFSObjects, string) {
+		disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+		obj := initFSObjects(disk, t)
+		fs := obj.(*PANFSObjects)
+
+		objectContent := "12345"
+		obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
+		obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), ObjectOptions{})
+		return fs, disk
+	}
+
+	// Test Shutdown with regular conditions
+	fs, disk := prepareTest()
+	if err := fs.Shutdown(GlobalContext); err != nil {
+		t.Fatal("Cannot shutdown the PANFS object: ", err)
+	}
+	os.RemoveAll(disk)
+
+	// Test Shutdown with faulty disk
+	fs, disk = prepareTest()
+	fs.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{})
+	os.RemoveAll(disk)
+	if err := fs.Shutdown(GlobalContext); err != nil {
+		t.Fatal("Got unexpected fs shutdown error: ", err)
+	}
+}
+
+// TestPANFSGetBucketInfo - test GetBucketInfo with healty and faulty disks
+func TestPANFSGetBucketInfo(t *testing.T) {
+	t.Skip()
+
+	// Prepare for testing
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+	bucketName := "bucket"
+
+	err := obj.MakeBucketWithLocation(GlobalContext, "a", MakeBucketOptions{})
+	if !isSameType(err, BucketNameInvalid{}) {
+		t.Fatal("BucketNameInvalid error not returned")
+	}
+
+	err = obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test with valid parameters
+	info, err := fs.GetBucketInfo(GlobalContext, bucketName, BucketOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Name != bucketName {
+		t.Fatalf("wrong bucket name, expected: %s, found: %s", bucketName, info.Name)
+	}
+
+	// Test with non-existent bucket
+	_, err = fs.GetBucketInfo(GlobalContext, "a", BucketOptions{})
+	if !isSameType(err, BucketNotFound{}) {
+		t.Fatal("BucketNotFound error not returned")
+	}
+
+	// Check for buckets and should get disk not found.
+	os.RemoveAll(disk)
+
+	if _, err = fs.GetBucketInfo(GlobalContext, bucketName, BucketOptions{}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("BucketNotFound error not returned")
+		}
+	}
+}
+
+func TestPANFSPutObject(t *testing.T) {
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	bucketName := "bucket"
+	objectName := "1/2/3/4/object"
+
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// With a regular object.
+	_, err := obj.PutObject(GlobalContext, bucketName+"non-existent", objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{})
+	if err == nil {
+		t.Fatal("Unexpected should fail here, bucket doesn't exist")
+	}
+	if _, ok := err.(BucketNotFound); !ok {
+		t.Fatalf("Expected error type BucketNotFound, got %#v", err)
+	}
+
+	// With a directory object.
+	_, err = obj.PutObject(GlobalContext, bucketName+"non-existent", objectName+SlashSeparator, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), 0, "", ""), ObjectOptions{})
+	if err == nil {
+		t.Fatal("Unexpected should fail here, bucket doesn't exist")
+	}
+	if _, ok := err.(BucketNotFound); !ok {
+		t.Fatalf("Expected error type BucketNotFound, got %#v", err)
+	}
+
+	_, err = obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPANFSDeleteObject - test fs.DeleteObject() with healthy and corrupted disks
+func TestPANFSDeleteObject(t *testing.T) {
+	t.Skip()
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+	bucketName := "bucket"
+	objectName := "object"
+
+	obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
+	obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{})
+
+	// Test with invalid bucket name
+	if _, err := fs.DeleteObject(GlobalContext, "fo", objectName, ObjectOptions{}); !isSameType(err, BucketNameInvalid{}) {
+		t.Fatal("Unexpected error: ", err)
+	}
+	// Test with bucket does not exist
+	if _, err := fs.DeleteObject(GlobalContext, "foobucket", "fooobject", ObjectOptions{}); !isSameType(err, BucketNotFound{}) {
+		t.Fatal("Unexpected error: ", err)
+	}
+	// Test with invalid object name
+	if _, err := fs.DeleteObject(GlobalContext, bucketName, "\\", ObjectOptions{}); !(isSameType(err, ObjectNotFound{}) || isSameType(err, ObjectNameInvalid{})) {
+		t.Fatal("Unexpected error: ", err)
+	}
+	// Test with object does not exist.
+	if _, err := fs.DeleteObject(GlobalContext, bucketName, "foooobject", ObjectOptions{}); !isSameType(err, ObjectNotFound{}) {
+		t.Fatal("Unexpected error: ", err)
+	}
+	// Test with valid condition
+	if _, err := fs.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	// Delete object should err disk not found.
+	os.RemoveAll(disk)
+	if _, err := fs.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error: ", err)
+		}
+	}
+}
+
+// TestPANFSDeleteBucket - tests for fs DeleteBucket
+func TestPANFSDeleteBucket(t *testing.T) {
+	t.Skip()
+	// Prepare for testing
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+	bucketName := "bucket"
+
+	err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	// Test with an invalid bucket name
+	if err = fs.DeleteBucket(GlobalContext, "fo", DeleteBucketOptions{}); !isSameType(err, BucketNotFound{}) {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	// Test with an inexistant bucket
+	if err = fs.DeleteBucket(GlobalContext, "foobucket", DeleteBucketOptions{}); !isSameType(err, BucketNotFound{}) {
+		t.Fatal("Unexpected error: ", err)
+	}
+	// Test with a valid case
+	if err = fs.DeleteBucket(GlobalContext, bucketName, DeleteBucketOptions{}); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
+
+	// Delete bucket should get error disk not found.
+	os.RemoveAll(disk)
+	if err = fs.DeleteBucket(GlobalContext, bucketName, DeleteBucketOptions{}); err != nil {
+		if !isSameType(err, BucketNotFound{}) {
+			t.Fatal("Unexpected error: ", err)
+		}
+	}
+}
+
+// TestPANFSListBuckets - tests for fs ListBuckets
+func TestPANFSListBuckets(t *testing.T) {
+	t.Skip()
+	// Prepare for tests
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	fs := obj.(*PANFSObjects)
+
+	bucketName := "bucket"
+	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	// Create a bucket with invalid name
+	if err := os.MkdirAll(pathJoin(fs.fsPath, "vo^"), 0o777); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+	f, err := os.Create(pathJoin(fs.fsPath, "test"))
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+	f.Close()
+
+	// Test list buckets to have only one entry.
+	buckets, err := fs.ListBuckets(GlobalContext, BucketOptions{})
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+	if len(buckets) != 1 {
+		t.Fatal("ListBuckets not working properly", buckets)
+	}
+
+	// Test ListBuckets with disk not found.
+	os.RemoveAll(disk)
+	if _, err := fs.ListBuckets(GlobalContext, BucketOptions{}); err != nil {
+		if err != errDiskNotFound {
+			t.Fatal("Unexpected error: ", err)
+		}
+	}
+}
+
+// TestPANFSHealObject - tests for fs HealObject
+func TestPANFSHealObject(t *testing.T) {
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	_, err := obj.HealObject(GlobalContext, "bucket", "object", "", madmin.HealOpts{})
+	if err == nil || !isSameType(err, NotImplemented{}) {
+		t.Fatalf("Heal Object should return NotImplemented error ")
+	}
+}
+
+// TestPANFSHealObjects - tests for fs HealObjects to return not implemented.
+func TestPANFSHealObjects(t *testing.T) {
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	obj := initFSObjects(disk, t)
+	err := obj.HealObjects(GlobalContext, "bucket", "prefix", madmin.HealOpts{}, nil)
+	if err == nil || !isSameType(err, NotImplemented{}) {
+		t.Fatalf("Heal Object should return NotImplemented error ")
+	}
+}

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/minio/madmin-go"
 )
 
 // TestNewPANFS - tests initialization of all input disks


### PR DESCRIPTION
## Description

- Added new MinIO runner minio gateway panfs
- Added new panfs-fs-v1 filesystem backend
- Added nests for panfs-fs-v1* filesystem backend. Just copy and paste of the fs-v1*-test

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
