### PR TITLE
Implement IAM and bucket configuration reload via signal

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -221,9 +221,10 @@ var (
 
 	globalTLSCerts *certs.Manager
 
-	globalHTTPServer        *xhttp.Server
-	globalHTTPServerErrorCh = make(chan error)
-	globalOSSignalCh        = make(chan os.Signal, 1)
+	globalHTTPServer         *xhttp.Server
+	globalHTTPServerErrorCh  = make(chan error)
+	globalOSSignalCh         = make(chan os.Signal, 1)
+	globalConfReloadSignalCh = make(chan os.Signal, 1)
 
 	// global Trace system to send HTTP request/response
 	// and Storage/OS calls info to registered listeners.

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -20,9 +20,12 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/minio/minio/internal/logger"
 )
@@ -97,6 +100,25 @@ func handleSignals() {
 			case serviceStop:
 				logger.Info("Stopping on service signal")
 				exit(stopProcess())
+			}
+		case confReloadSignal := <-globalConfReloadSignalCh:
+			logger.Info("%s signal received. Start reloading MinIO IAM sub-system", strings.ToUpper(confReloadSignal.String()))
+			// Reload IAM data from storage.
+			retryCtx, _ := context.WithCancel(GlobalContext)
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			for {
+				if err := globalIAMSys.Load(retryCtx); err != nil {
+					if configRetriableErrors(err) {
+						logger.Info("Waiting for all MinIO IAM sub-system to be reload.. possible cause (%v)", err)
+						time.Sleep(time.Duration(r.Float64() * float64(5*time.Second)))
+						continue
+					}
+					if err != nil {
+						logger.Info("Unable to reload IAM sub-system, some users may not be available %w", err)
+						logger.LogIf(GlobalContext, fmt.Errorf("Unable to reload IAM sub-system, some users may not be available %w", err))
+					}
+				}
+				break
 			}
 		}
 	}

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -113,10 +113,8 @@ func handleSignals() {
 						time.Sleep(time.Duration(r.Float64() * float64(5*time.Second)))
 						continue
 					}
-					if err != nil {
-						logger.Info("Unable to reload IAM sub-system, some users may not be available %w", err)
-						logger.LogIf(GlobalContext, fmt.Errorf("Unable to reload IAM sub-system, some users may not be available %w", err))
-					}
+					logger.Info("Unable to reload IAM sub-system, some users may not be available %w", err)
+					logger.LogIf(GlobalContext, fmt.Errorf("Unable to reload IAM sub-system, some users may not be available %w", err))
 				}
 				break
 			}


### PR DESCRIPTION
## Description

- Implemented IAM configuration reload by SIGUSR1 signal for 'panfs gateway'

## Motivation and Context


## How to test this PR?

- Run minio on the two different nodes in `gateway panfs` mode
- Create `mypanfs1 ` and `mypanfs2` aliases
  ```
  mc alias set mypanfs1 http://node1:9000 minio minio123
  mc alias set mypanfs2 http://node2:9000 minio minio123
  ```
- Create new user for `mypanfs1`
  ```
  mc admin user add mypanfs1/ 'random_user4' 'random_passphrase3
  ```
- Get list of user for `mypanfs1` and  `mypanfs2`.  `mypanfs1` has `random_user4` but  `mypanfs2` has not.
- Send `USR1 ` signal for node2 `kill -s USR1 minio_id`
- Get list of user for `mypanfs1` and  `mypanfs2`. Both have  `random_user4`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
