### PR TITLE
Store object metadata to the location specified by panfs-path location

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -434,7 +434,8 @@ func (fs *PANFSObjects) getBucketDir(ctx context.Context, bucket string) (string
 	return bucketDir, nil
 }
 
-// loadBucketMetadata loads bucket metadata. This function is slightly different from bucket-metadata:loadBucketMetadata
+// loadBucketMetadata loads bucket metadata from the disk. TODO: this function should use the configuration agent
+// Returns an error when the bucket metadata file not found
 func (fs *PANFSObjects) loadBucketMetadata(ctx context.Context, bucket string) (BucketMetadata, error) {
 	b := newBucketMetadata(bucket)
 	err := b.Load(ctx, fs, b.Name)
@@ -1339,7 +1340,7 @@ func (fs *PANFSObjects) listDirFactory() ListDirFunc {
 		if len(entries) == 0 {
 			return true, nil, false
 		}
-		entries = fs.filterPanFSS3Dir(entries)
+		entries = fs.filterOutPanFSS3Dir(entries)
 		entries, delayIsLeaf = filterListEntries(bucket, prefixDir, entries, prefixEntry, fs.isLeaf)
 		return false, entries, delayIsLeaf
 	}
@@ -1348,8 +1349,8 @@ func (fs *PANFSObjects) listDirFactory() ListDirFunc {
 	return listDir
 }
 
-// filterPanFSS3Dir return entries that does not have .s3 prefix
-func (fs *PANFSObjects) filterPanFSS3Dir(entries []string) (filtered []string) {
+// filterPanFSS3Dir removes entries with .s3 prefix from the result
+func (fs *PANFSObjects) filterOutPanFSS3Dir(entries []string) (filtered []string) {
 	filtered = entries[:0]
 	for _, entry := range entries {
 		if HasPrefix(entry, ".s3") {

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1339,12 +1339,25 @@ func (fs *PANFSObjects) listDirFactory() ListDirFunc {
 		if len(entries) == 0 {
 			return true, nil, false
 		}
+		entries = fs.filterPanFSS3Dir(entries)
 		entries, delayIsLeaf = filterListEntries(bucket, prefixDir, entries, prefixEntry, fs.isLeaf)
 		return false, entries, delayIsLeaf
 	}
 
 	// Return list factory instance.
 	return listDir
+}
+
+// filterPanFSS3Dir return entries that does not have .s3 prefix
+func (fs *PANFSObjects) filterPanFSS3Dir(entries []string) (filtered []string) {
+	filtered = entries[:0]
+	for _, entry := range entries {
+		if HasPrefix(entry, ".s3") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return
 }
 
 // isObjectDir returns true if the specified bucket & prefix exists


### PR DESCRIPTION
## Description

This change introduces the feature that allow to store object metadata to the non-standard location. This location can be specified on the server startup by setting up env variable `MINIO_PANFS_BUCKET_PATH`. Another option is to set `--panfs-path` due to bucket creation (`mc mb --panfs-path <custom_path>`).

At the moment only object metadata is stored on the new location. 

```
/home/dmitri_zavadski/Downloads/empty/.s3/
└── buckets
    └── outer
        ├── some.file
        │   └── panfs.json
        └── part.deb
            └── panfs.json
```

```
/home/dmitri_zavadski/minio_panfs_gateway/
├── buckets
│   ├── outer
│   │   └── .metadata.bin
│   └── .tracker.bin
└── outer
    ├── some.file
    └── part.ded
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
