### PR TITLE
Allow access to Admin and Peer APIs only from localhost

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -18,13 +18,14 @@
 package cmd
 
 import (
-	"net/http"
-
+	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/klauspost/compress/gzip"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/logger"
+	"net/http"
+	"strings"
 )
 
 const (
@@ -35,6 +36,26 @@ const (
 
 // adminAPIHandlers provides HTTP handlers for MinIO admin API.
 type adminAPIHandlers struct{}
+
+// adminApiHostHandler - allow access to the  Admin APIs only from local interface by default.
+func adminApiHostHandler(f func(w http.ResponseWriter, r *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if globalIsGateway && globalGatewayName == PANFSBackendGateway && globalPanOnlyLocalAdminApi {
+			host := strings.Split(r.Host, ":")[0]
+			if host == "localhost" || host == "127.0.0.1" {
+				f(w, r)
+			} else {
+				writeErrorResponse(r.Context(), w, APIError{
+					Code:           "Forbidden",
+					Description:    fmt.Sprintf("Admin API allowed from localhost only by default"),
+					HTTPStatusCode: http.StatusForbidden,
+				}, r.URL)
+			}
+		} else {
+			f(w, r)
+		}
+	}
+}
 
 // registerAdminRouter - Add handler functions for each service REST API routes.
 func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
@@ -54,235 +75,354 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 
 	for _, adminVersion := range adminVersions {
 		// Restart and stop MinIO service.
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/service").HandlerFunc(gz(httpTraceAll(adminAPI.ServiceHandler))).Queries("action", "{action:.*}")
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/service").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServiceHandler)))).
+			Queries("action", "{action:.*}")
 		// Update MinIO servers.
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update").HandlerFunc(gz(httpTraceAll(adminAPI.ServerUpdateHandler))).Queries("updateURL", "{updateURL:.*}")
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServerUpdateHandler)))).
+			Queries("updateURL", "{updateURL:.*}")
 
 		// Info operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/info").HandlerFunc(gz(httpTraceAll(adminAPI.ServerInfoHandler)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/inspect-data").HandlerFunc(httpTraceHdrs(adminAPI.InspectDataHandler)).Queries("volume", "{volume:.*}", "file", "{file:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/info").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServerInfoHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/inspect-data").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.InspectDataHandler))).
+			Queries("volume", "{volume:.*}", "file", "{file:.*}")
 
 		// StorageInfo operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/storageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.StorageInfoHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/storageinfo").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StorageInfoHandler))))
 		// DataUsageInfo operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/datausageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.DataUsageInfoHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/datausageinfo").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.DataUsageInfoHandler))))
 		// Metrics operation
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/metrics").HandlerFunc(gz(httpTraceAll(adminAPI.MetricsHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/metrics").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.MetricsHandler))))
 
 		if globalIsDistErasure || globalIsErasure {
 			// Heal operations
 
 			// Heal processing endpoint.
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}/{prefix:.*}").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/background-heal/status").HandlerFunc(gz(httpTraceAll(adminAPI.BackgroundHealStatusHandler)))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}/{prefix:.*}").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/background-heal/status").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.BackgroundHealStatusHandler))))
 
 			// Pool operations
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/pools/list").HandlerFunc(gz(httpTraceAll(adminAPI.ListPools)))
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/pools/status").HandlerFunc(gz(httpTraceAll(adminAPI.StatusPool))).Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/pools/list").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ListPools))))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/pools/status").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StatusPool)))).
+				Queries("pool", "{pool:.*}")
 
-			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/decommission").HandlerFunc(gz(httpTraceAll(adminAPI.StartDecommission))).Queries("pool", "{pool:.*}")
-			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/cancel").HandlerFunc(gz(httpTraceAll(adminAPI.CancelDecommission))).Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/decommission").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StartDecommission)))).
+				Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/cancel").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.CancelDecommission)))).
+				Queries("pool", "{pool:.*}")
 		}
 
 		// Profiling operations - deprecated API
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/profiling/start").HandlerFunc(gz(httpTraceAll(adminAPI.StartProfilingHandler))).
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/profiling/start").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StartProfilingHandler)))).
 			Queries("profilerType", "{profilerType:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/profiling/download").HandlerFunc(gz(httpTraceAll(adminAPI.DownloadProfilingHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/profiling/download").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.DownloadProfilingHandler))))
 		// Profiling operations
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/profile").HandlerFunc(gz(httpTraceAll(adminAPI.ProfileHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/profile").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ProfileHandler))))
 
 		// Config KV operations.
 		if enableConfigOps {
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetConfigKVHandler))).Queries("key", "{key:.*}")
-			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/set-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetConfigKVHandler)))
-			adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/del-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.DelConfigKVHandler)))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-config-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetConfigKVHandler)))).
+				Queries("key", "{key:.*}")
+			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/set-config-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetConfigKVHandler))))
+			adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/del-config-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DelConfigKVHandler))))
 		}
 
 		// Enable config help in all modes.
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/help-config-kv").HandlerFunc(gz(httpTraceAll(adminAPI.HelpConfigKVHandler))).Queries("subSys", "{subSys:.*}", "key", "{key:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/help-config-kv").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HelpConfigKVHandler)))).
+			Queries("subSys", "{subSys:.*}", "key", "{key:.*}")
 
 		// Config KV history operations.
 		if enableConfigOps {
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-config-history-kv").HandlerFunc(gz(httpTraceAll(adminAPI.ListConfigHistoryKVHandler))).Queries("count", "{count:[0-9]+}")
-			adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/clear-config-history-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.ClearConfigHistoryKVHandler))).Queries("restoreId", "{restoreId:.*}")
-			adminRouter.Methods(http.MethodPut).Path(adminVersion+"/restore-config-history-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.RestoreConfigHistoryKVHandler))).Queries("restoreId", "{restoreId:.*}")
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-config-history-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ListConfigHistoryKVHandler)))).
+				Queries("count", "{count:[0-9]+}")
+			adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/clear-config-history-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ClearConfigHistoryKVHandler)))).
+				Queries("restoreId", "{restoreId:.*}")
+			adminRouter.Methods(http.MethodPut).Path(adminVersion+"/restore-config-history-kv").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RestoreConfigHistoryKVHandler)))).
+				Queries("restoreId", "{restoreId:.*}")
 		}
 
 		// Config import/export bulk operations
 		if enableConfigOps {
 			// Get config
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/config").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetConfigHandler)))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/config").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetConfigHandler))))
 			// Set config
-			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/config").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetConfigHandler)))
+			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/config").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetConfigHandler))))
 		}
 
 		// -- IAM APIs --
 
 		// Add policy IAM
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-canned-policy").HandlerFunc(gz(httpTraceAll(adminAPI.AddCannedPolicy))).Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-canned-policy").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.AddCannedPolicy)))).
+			Queries("name", "{name:.*}")
 
 		// Add user IAM
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/accountinfo").HandlerFunc(gz(httpTraceAll(adminAPI.AccountInfoHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/accountinfo").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.AccountInfoHandler))))
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-user").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddUser))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-user").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddUser)))).
+			Queries("accessKey", "{accessKey:.*}")
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetUserStatus))).Queries("accessKey", "{accessKey:.*}").Queries("status", "{status:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-status").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetUserStatus)))).
+			Queries("accessKey", "{accessKey:.*}").Queries("status", "{status:.*}")
 
 		// Service accounts ops
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/add-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddServiceAccount)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.UpdateServiceAccount))).Queries("accessKey", "{accessKey:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.InfoServiceAccount))).Queries("accessKey", "{accessKey:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-service-accounts").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListServiceAccounts)))
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/delete-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.DeleteServiceAccount))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/add-service-account").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddServiceAccount))))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update-service-account").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.UpdateServiceAccount)))).
+			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-service-account").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.InfoServiceAccount)))).
+			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-service-accounts").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListServiceAccounts))))
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/delete-service-account").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DeleteServiceAccount)))).
+			Queries("accessKey", "{accessKey:.*}")
 
 		// Info policy IAM latest
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-canned-policy").HandlerFunc(gz(httpTraceHdrs(adminAPI.InfoCannedPolicy))).Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-canned-policy").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.InfoCannedPolicy)))).
+			Queries("name", "{name:.*}")
 		// List policies latest
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-canned-policies").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListBucketPolicies))).Queries("bucket", "{bucket:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-canned-policies").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListCannedPolicies)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-canned-policies").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBucketPolicies)))).
+			Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-canned-policies").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListCannedPolicies))))
 
 		// Remove policy IAM
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-canned-policy").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveCannedPolicy))).Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-canned-policy").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveCannedPolicy)))).
+			Queries("name", "{name:.*}")
 
 		// Set user or group policy
 		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-or-group-policy").
-			HandlerFunc(gz(httpTraceHdrs(adminAPI.SetPolicyForUserOrGroup))).
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetPolicyForUserOrGroup)))).
 			Queries("policyName", "{policyName:.*}", "userOrGroup", "{userOrGroup:.*}", "isGroup", "{isGroup:true|false}")
 
 		// Remove user IAM
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-user").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveUser))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-user").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveUser)))).
+			Queries("accessKey", "{accessKey:.*}")
 
 		// List users
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-users").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListBucketUsers))).Queries("bucket", "{bucket:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-users").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListUsers)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-users").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBucketUsers)))).
+			Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-users").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListUsers))))
 
 		// User info
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/user-info").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetUserInfo))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/user-info").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetUserInfo)))).
+			Queries("accessKey", "{accessKey:.*}")
 		// Add/Remove members from group
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/update-group-members").HandlerFunc(gz(httpTraceHdrs(adminAPI.UpdateGroupMembers)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/update-group-members").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.UpdateGroupMembers))))
 
 		// Get Group
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/group").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetGroup))).Queries("group", "{group:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/group").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetGroup)))).
+			Queries("group", "{group:.*}")
 
 		// List Groups
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/groups").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListGroups)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/groups").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListGroups))))
 
 		// Set Group Status
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-group-status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetGroupStatus))).Queries("group", "{group:.*}").Queries("status", "{status:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-group-status").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetGroupStatus)))).
+			Queries("group", "{group:.*}").Queries("status", "{status:.*}")
 
 		// Export IAM info to zipped file
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-iam").HandlerFunc(httpTraceHdrs(adminAPI.ExportIAM))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-iam").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ExportIAM)))
 
 		// Import IAM info
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam").HandlerFunc(httpTraceHdrs(adminAPI.ImportIAM))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ImportIAM)))
 
 		// IDentity Provider configuration APIs
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetIdentityProviderCfg))).Queries("type", "{type:.*}").Queries("name", "{name:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetIdentityProviderCfg))).Queries("type", "{type:.*}")
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.DeleteIdentityProviderCfg))).Queries("type", "{type:.*}").Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/idp-config").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetIdentityProviderCfg)))).
+			Queries("type", "{type:.*}").Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/idp-config").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetIdentityProviderCfg)))).
+			Queries("type", "{type:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/idp-config").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DeleteIdentityProviderCfg)))).
+			Queries("type", "{type:.*}").Queries("name", "{name:.*}")
 
 		// -- END IAM APIs --
 
 		// GetBucketQuotaConfig
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-quota").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.GetBucketQuotaConfigHandler))).Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-quota").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetBucketQuotaConfigHandler)))).
+			Queries("bucket", "{bucket:.*}")
 		// PutBucketQuotaConfig
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-bucket-quota").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.PutBucketQuotaConfigHandler))).Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-bucket-quota").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.PutBucketQuotaConfigHandler)))).
+			Queries("bucket", "{bucket:.*}")
 
 		// Bucket replication operations
 		// GetBucketTargetHandler
 		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-remote-targets").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.ListRemoteTargetsHandler))).Queries("bucket", "{bucket:.*}", "type", "{type:.*}")
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListRemoteTargetsHandler)))).
+			Queries("bucket", "{bucket:.*}", "type", "{type:.*}")
 		// SetRemoteTargetHandler
 		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-remote-target").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.SetRemoteTargetHandler))).Queries("bucket", "{bucket:.*}")
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetRemoteTargetHandler)))).
+			Queries("bucket", "{bucket:.*}")
 		// RemoveRemoteTargetHandler
 		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-remote-target").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.RemoveRemoteTargetHandler))).Queries("bucket", "{bucket:.*}", "arn", "{arn:.*}")
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveRemoteTargetHandler)))).
+			Queries("bucket", "{bucket:.*}", "arn", "{arn:.*}")
 		// ReplicationDiff - MinIO extension API
 		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/replication/diff").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.ReplicationDiffHandler))).Queries("bucket", "{bucket:.*}")
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ReplicationDiffHandler)))).
+			Queries("bucket", "{bucket:.*}")
 
 		// Batch job operations
 		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/start-job").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.StartBatchJob)))
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.StartBatchJob))))
 
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-jobs").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.ListBatchJobs)))
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBatchJobs))))
 
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/describe-job").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.DescribeBatchJob)))
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DescribeBatchJob))))
 
 		// Bucket migration operations
 		// ExportBucketMetaHandler
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-bucket-metadata").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.ExportBucketMetadataHandler)))
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ExportBucketMetadataHandler))))
 		// ImportBucketMetaHandler
 		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-bucket-metadata").HandlerFunc(
-			gz(httpTraceHdrs(adminAPI.ImportBucketMetadataHandler)))
+			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ImportBucketMetadataHandler))))
 
 		// Remote Tier management operations
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/tier").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddTierHandler)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.EditTierHandler)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListTierHandler)))
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveTierHandler)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.VerifyTierHandler)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/tier").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddTierHandler))))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/tier/{tier}").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.EditTierHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListTierHandler))))
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/tier/{tier}").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveTierHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier/{tier}").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.VerifyTierHandler))))
 		// Tier stats
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier-stats").HandlerFunc(gz(httpTraceHdrs(adminAPI.TierStatsHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier-stats").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.TierStatsHandler))))
 
 		// Cluster Replication APIs
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/add").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationAdd)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/remove").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationRemove)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/info").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationInfo)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/metainfo").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationMetaInfo)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationStatus)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/add").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationAdd))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/remove").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationRemove))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/info").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationInfo))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/metainfo").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationMetaInfo))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/status").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationStatus))))
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/join").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerJoin)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/site-replication/peer/bucket-ops").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerBucketOps))).Queries("bucket", "{bucket:.*}").Queries("operation", "{operation:.*}")
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/iam-item").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerReplicateIAMItem)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/bucket-meta").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerReplicateBucketItem)))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/peer/idp-settings").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerGetIDPSettings)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/edit").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationEdit)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/edit").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerEdit)))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/remove").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerRemove)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/join").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerJoin))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/site-replication/peer/bucket-ops").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerBucketOps)))).
+			Queries("bucket", "{bucket:.*}").Queries("operation", "{operation:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/iam-item").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerReplicateIAMItem))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/bucket-meta").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerReplicateBucketItem))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/peer/idp-settings").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerGetIDPSettings))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/edit").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationEdit))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/edit").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerEdit))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/remove").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerRemove))))
 
 		if globalIsDistErasure {
 			// Top locks
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/top/locks").HandlerFunc(gz(httpTraceHdrs(adminAPI.TopLocksHandler)))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/top/locks").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.TopLocksHandler))))
 			// Force unlocks paths
 			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/force-unlock").
-				Queries("paths", "{paths:.*}").HandlerFunc(gz(httpTraceHdrs(adminAPI.ForceUnlockHandler)))
+				Queries("paths", "{paths:.*}").
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ForceUnlockHandler))))
 		}
 
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").HandlerFunc(httpTraceHdrs(adminAPI.SpeedTestHandler))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").HandlerFunc(httpTraceHdrs(adminAPI.ObjectSpeedTestHandler))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/drive").HandlerFunc(httpTraceHdrs(adminAPI.DriveSpeedtestHandler))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/net").HandlerFunc(httpTraceHdrs(adminAPI.NetperfHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.SpeedTestHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ObjectSpeedTestHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/drive").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.DriveSpeedtestHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/net").
+			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.NetperfHandler)))
 
 		// HTTP Trace
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/trace").HandlerFunc(gz(http.HandlerFunc(adminAPI.TraceHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/trace").
+			HandlerFunc(adminApiHostHandler(gz(http.HandlerFunc(adminAPI.TraceHandler))))
 
 		// Console Logs
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/log").HandlerFunc(gz(httpTraceAll(adminAPI.ConsoleLogHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/log").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ConsoleLogHandler))))
 
 		// -- KMS APIs --
 		//
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/kms/status").HandlerFunc(gz(httpTraceAll(adminAPI.KMSStatusHandler)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/kms/key/create").HandlerFunc(gz(httpTraceAll(adminAPI.KMSCreateKeyHandler))).Queries("key-id", "{key-id:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/kms/key/status").HandlerFunc(gz(httpTraceAll(adminAPI.KMSKeyStatusHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/kms/status").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSStatusHandler))))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/kms/key/create").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSCreateKeyHandler)))).
+			Queries("key-id", "{key-id:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/kms/key/status").
+			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSKeyStatusHandler))))
 
 		if !globalIsGateway {
 			// Keep obdinfo for backward compatibility with mc
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/obdinfo").
-				HandlerFunc(gz(httpTraceHdrs(adminAPI.HealthInfoHandler)))
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.HealthInfoHandler))))
 			// -- Health API --
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/healthinfo").
-				HandlerFunc(gz(httpTraceHdrs(adminAPI.HealthInfoHandler)))
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.HealthInfoHandler))))
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/bandwidth").
-				HandlerFunc(gz(httpTraceHdrs(adminAPI.BandwidthMonitorHandler)))
+				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.BandwidthMonitorHandler))))
 		}
 	}
 

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -38,12 +38,12 @@ const (
 type adminAPIHandlers struct{}
 
 // adminApiHostHandler - allow access to the  Admin APIs only from local interface by default.
-func adminApiHostHandler(f func(w http.ResponseWriter, r *http.Request)) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+func adminApiHostHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if globalIsGateway && globalGatewayName == PANFSBackendGateway && globalPanOnlyLocalAdminApi {
 			host := strings.Split(r.Host, ":")[0]
 			if host == "localhost" || host == "127.0.0.1" {
-				f(w, r)
+				next.ServeHTTP(w, r)
 			} else {
 				writeErrorResponse(r.Context(), w, APIError{
 					Code:           "Forbidden",
@@ -52,9 +52,9 @@ func adminApiHostHandler(f func(w http.ResponseWriter, r *http.Request)) func(ht
 				}, r.URL)
 			}
 		} else {
-			f(w, r)
+			next.ServeHTTP(w, r)
 		}
-	}
+	})
 }
 
 // registerAdminRouter - Add handler functions for each service REST API routes.
@@ -75,356 +75,239 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 
 	for _, adminVersion := range adminVersions {
 		// Restart and stop MinIO service.
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/service").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServiceHandler)))).
-			Queries("action", "{action:.*}")
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/service").HandlerFunc(gz(httpTraceAll(adminAPI.ServiceHandler))).Queries("action", "{action:.*}")
 		// Update MinIO servers.
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServerUpdateHandler)))).
-			Queries("updateURL", "{updateURL:.*}")
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update").HandlerFunc(gz(httpTraceAll(adminAPI.ServerUpdateHandler))).Queries("updateURL", "{updateURL:.*}")
 
 		// Info operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/info").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ServerInfoHandler))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/inspect-data").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.InspectDataHandler))).
-			Queries("volume", "{volume:.*}", "file", "{file:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/info").HandlerFunc(gz(httpTraceAll(adminAPI.ServerInfoHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/inspect-data").HandlerFunc(httpTraceHdrs(adminAPI.InspectDataHandler)).Queries("volume", "{volume:.*}", "file", "{file:.*}")
 
 		// StorageInfo operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/storageinfo").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StorageInfoHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/storageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.StorageInfoHandler)))
 		// DataUsageInfo operations
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/datausageinfo").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.DataUsageInfoHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/datausageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.DataUsageInfoHandler)))
 		// Metrics operation
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/metrics").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.MetricsHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/metrics").HandlerFunc(gz(httpTraceAll(adminAPI.MetricsHandler)))
 
 		if globalIsDistErasure || globalIsErasure {
 			// Heal operations
 
 			// Heal processing endpoint.
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}/{prefix:.*}").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HealHandler))))
-			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/background-heal/status").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.BackgroundHealStatusHandler))))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/heal/{bucket}/{prefix:.*}").HandlerFunc(gz(httpTraceAll(adminAPI.HealHandler)))
+			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/background-heal/status").HandlerFunc(gz(httpTraceAll(adminAPI.BackgroundHealStatusHandler)))
 
 			// Pool operations
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/pools/list").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ListPools))))
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/pools/status").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StatusPool)))).
-				Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/pools/list").HandlerFunc(gz(httpTraceAll(adminAPI.ListPools)))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/pools/status").HandlerFunc(gz(httpTraceAll(adminAPI.StatusPool))).Queries("pool", "{pool:.*}")
 
-			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/decommission").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StartDecommission)))).
-				Queries("pool", "{pool:.*}")
-			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/cancel").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.CancelDecommission)))).
-				Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/decommission").HandlerFunc(gz(httpTraceAll(adminAPI.StartDecommission))).Queries("pool", "{pool:.*}")
+			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/pools/cancel").HandlerFunc(gz(httpTraceAll(adminAPI.CancelDecommission))).Queries("pool", "{pool:.*}")
 		}
 
 		// Profiling operations - deprecated API
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/profiling/start").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.StartProfilingHandler)))).
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/profiling/start").HandlerFunc(gz(httpTraceAll(adminAPI.StartProfilingHandler))).
 			Queries("profilerType", "{profilerType:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/profiling/download").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.DownloadProfilingHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/profiling/download").HandlerFunc(gz(httpTraceAll(adminAPI.DownloadProfilingHandler)))
 		// Profiling operations
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/profile").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ProfileHandler))))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/profile").HandlerFunc(gz(httpTraceAll(adminAPI.ProfileHandler)))
 
 		// Config KV operations.
 		if enableConfigOps {
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-config-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetConfigKVHandler)))).
-				Queries("key", "{key:.*}")
-			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/set-config-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetConfigKVHandler))))
-			adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/del-config-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DelConfigKVHandler))))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetConfigKVHandler))).Queries("key", "{key:.*}")
+			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/set-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetConfigKVHandler)))
+			adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/del-config-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.DelConfigKVHandler)))
 		}
 
 		// Enable config help in all modes.
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/help-config-kv").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.HelpConfigKVHandler)))).
-			Queries("subSys", "{subSys:.*}", "key", "{key:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/help-config-kv").HandlerFunc(gz(httpTraceAll(adminAPI.HelpConfigKVHandler))).Queries("subSys", "{subSys:.*}", "key", "{key:.*}")
 
 		// Config KV history operations.
 		if enableConfigOps {
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-config-history-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ListConfigHistoryKVHandler)))).
-				Queries("count", "{count:[0-9]+}")
-			adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/clear-config-history-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ClearConfigHistoryKVHandler)))).
-				Queries("restoreId", "{restoreId:.*}")
-			adminRouter.Methods(http.MethodPut).Path(adminVersion+"/restore-config-history-kv").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RestoreConfigHistoryKVHandler)))).
-				Queries("restoreId", "{restoreId:.*}")
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-config-history-kv").HandlerFunc(gz(httpTraceAll(adminAPI.ListConfigHistoryKVHandler))).Queries("count", "{count:[0-9]+}")
+			adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/clear-config-history-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.ClearConfigHistoryKVHandler))).Queries("restoreId", "{restoreId:.*}")
+			adminRouter.Methods(http.MethodPut).Path(adminVersion+"/restore-config-history-kv").HandlerFunc(gz(httpTraceHdrs(adminAPI.RestoreConfigHistoryKVHandler))).Queries("restoreId", "{restoreId:.*}")
 		}
 
 		// Config import/export bulk operations
 		if enableConfigOps {
 			// Get config
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/config").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetConfigHandler))))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/config").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetConfigHandler)))
 			// Set config
-			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/config").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetConfigHandler))))
+			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/config").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetConfigHandler)))
 		}
 
 		// -- IAM APIs --
 
 		// Add policy IAM
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-canned-policy").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.AddCannedPolicy)))).
-			Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-canned-policy").HandlerFunc(gz(httpTraceAll(adminAPI.AddCannedPolicy))).Queries("name", "{name:.*}")
 
 		// Add user IAM
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/accountinfo").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.AccountInfoHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/accountinfo").HandlerFunc(gz(httpTraceAll(adminAPI.AccountInfoHandler)))
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-user").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddUser)))).
-			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/add-user").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddUser))).Queries("accessKey", "{accessKey:.*}")
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-status").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetUserStatus)))).
-			Queries("accessKey", "{accessKey:.*}").Queries("status", "{status:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetUserStatus))).Queries("accessKey", "{accessKey:.*}").Queries("status", "{status:.*}")
 
 		// Service accounts ops
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/add-service-account").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddServiceAccount))))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update-service-account").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.UpdateServiceAccount)))).
-			Queries("accessKey", "{accessKey:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-service-account").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.InfoServiceAccount)))).
-			Queries("accessKey", "{accessKey:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-service-accounts").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListServiceAccounts))))
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/delete-service-account").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DeleteServiceAccount)))).
-			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/add-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddServiceAccount)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/update-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.UpdateServiceAccount))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.InfoServiceAccount))).Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-service-accounts").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListServiceAccounts)))
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/delete-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.DeleteServiceAccount))).Queries("accessKey", "{accessKey:.*}")
 
 		// Info policy IAM latest
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-canned-policy").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.InfoCannedPolicy)))).
-			Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-canned-policy").HandlerFunc(gz(httpTraceHdrs(adminAPI.InfoCannedPolicy))).Queries("name", "{name:.*}")
 		// List policies latest
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-canned-policies").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBucketPolicies)))).
-			Queries("bucket", "{bucket:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-canned-policies").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListCannedPolicies))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-canned-policies").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListBucketPolicies))).Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-canned-policies").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListCannedPolicies)))
 
 		// Remove policy IAM
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-canned-policy").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveCannedPolicy)))).
-			Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-canned-policy").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveCannedPolicy))).Queries("name", "{name:.*}")
 
 		// Set user or group policy
 		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-user-or-group-policy").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetPolicyForUserOrGroup)))).
+			HandlerFunc(gz(httpTraceHdrs(adminAPI.SetPolicyForUserOrGroup))).
 			Queries("policyName", "{policyName:.*}", "userOrGroup", "{userOrGroup:.*}", "isGroup", "{isGroup:true|false}")
 
 		// Remove user IAM
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-user").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveUser)))).
-			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-user").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveUser))).Queries("accessKey", "{accessKey:.*}")
 
 		// List users
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-users").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBucketUsers)))).
-			Queries("bucket", "{bucket:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-users").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListUsers))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-users").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListBucketUsers))).Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-users").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListUsers)))
 
 		// User info
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/user-info").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetUserInfo)))).
-			Queries("accessKey", "{accessKey:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/user-info").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetUserInfo))).Queries("accessKey", "{accessKey:.*}")
 		// Add/Remove members from group
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/update-group-members").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.UpdateGroupMembers))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/update-group-members").HandlerFunc(gz(httpTraceHdrs(adminAPI.UpdateGroupMembers)))
 
 		// Get Group
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/group").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetGroup)))).
-			Queries("group", "{group:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/group").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetGroup))).Queries("group", "{group:.*}")
 
 		// List Groups
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/groups").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListGroups))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/groups").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListGroups)))
 
 		// Set Group Status
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-group-status").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetGroupStatus)))).
-			Queries("group", "{group:.*}").Queries("status", "{status:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-group-status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetGroupStatus))).Queries("group", "{group:.*}").Queries("status", "{status:.*}")
 
 		// Export IAM info to zipped file
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-iam").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ExportIAM)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-iam").HandlerFunc(httpTraceHdrs(adminAPI.ExportIAM))
 
 		// Import IAM info
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ImportIAM)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam").HandlerFunc(httpTraceHdrs(adminAPI.ImportIAM))
 
 		// IDentity Provider configuration APIs
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/idp-config").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetIdentityProviderCfg)))).
-			Queries("type", "{type:.*}").Queries("name", "{name:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/idp-config").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetIdentityProviderCfg)))).
-			Queries("type", "{type:.*}")
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/idp-config").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DeleteIdentityProviderCfg)))).
-			Queries("type", "{type:.*}").Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.SetIdentityProviderCfg))).Queries("type", "{type:.*}").Queries("name", "{name:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.GetIdentityProviderCfg))).Queries("type", "{type:.*}")
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/idp-config").HandlerFunc(gz(httpTraceHdrs(adminAPI.DeleteIdentityProviderCfg))).Queries("type", "{type:.*}").Queries("name", "{name:.*}")
 
 		// -- END IAM APIs --
 
 		// GetBucketQuotaConfig
-		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-quota").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.GetBucketQuotaConfigHandler)))).
-			Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-quota").HandlerFunc(
+			gz(httpTraceHdrs(adminAPI.GetBucketQuotaConfigHandler))).Queries("bucket", "{bucket:.*}")
 		// PutBucketQuotaConfig
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-bucket-quota").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.PutBucketQuotaConfigHandler)))).
-			Queries("bucket", "{bucket:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-bucket-quota").HandlerFunc(
+			gz(httpTraceHdrs(adminAPI.PutBucketQuotaConfigHandler))).Queries("bucket", "{bucket:.*}")
 
 		// Bucket replication operations
 		// GetBucketTargetHandler
 		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-remote-targets").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListRemoteTargetsHandler)))).
-			Queries("bucket", "{bucket:.*}", "type", "{type:.*}")
+			gz(httpTraceHdrs(adminAPI.ListRemoteTargetsHandler))).Queries("bucket", "{bucket:.*}", "type", "{type:.*}")
 		// SetRemoteTargetHandler
 		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-remote-target").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SetRemoteTargetHandler)))).
-			Queries("bucket", "{bucket:.*}")
+			gz(httpTraceHdrs(adminAPI.SetRemoteTargetHandler))).Queries("bucket", "{bucket:.*}")
 		// RemoveRemoteTargetHandler
 		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-remote-target").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveRemoteTargetHandler)))).
-			Queries("bucket", "{bucket:.*}", "arn", "{arn:.*}")
+			gz(httpTraceHdrs(adminAPI.RemoveRemoteTargetHandler))).Queries("bucket", "{bucket:.*}", "arn", "{arn:.*}")
 		// ReplicationDiff - MinIO extension API
 		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/replication/diff").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ReplicationDiffHandler)))).
-			Queries("bucket", "{bucket:.*}")
+			gz(httpTraceHdrs(adminAPI.ReplicationDiffHandler))).Queries("bucket", "{bucket:.*}")
 
 		// Batch job operations
 		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/start-job").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.StartBatchJob))))
+			gz(httpTraceHdrs(adminAPI.StartBatchJob)))
 
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-jobs").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListBatchJobs))))
+			gz(httpTraceHdrs(adminAPI.ListBatchJobs)))
 
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/describe-job").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.DescribeBatchJob))))
+			gz(httpTraceHdrs(adminAPI.DescribeBatchJob)))
 
 		// Bucket migration operations
 		// ExportBucketMetaHandler
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/export-bucket-metadata").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ExportBucketMetadataHandler))))
+			gz(httpTraceHdrs(adminAPI.ExportBucketMetadataHandler)))
 		// ImportBucketMetaHandler
 		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-bucket-metadata").HandlerFunc(
-			adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ImportBucketMetadataHandler))))
+			gz(httpTraceHdrs(adminAPI.ImportBucketMetadataHandler)))
 
 		// Remote Tier management operations
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/tier").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.AddTierHandler))))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/tier/{tier}").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.EditTierHandler))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ListTierHandler))))
-		adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/tier/{tier}").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.RemoveTierHandler))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier/{tier}").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.VerifyTierHandler))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/tier").HandlerFunc(gz(httpTraceHdrs(adminAPI.AddTierHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.EditTierHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListTierHandler)))
+		adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.RemoveTierHandler)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier/{tier}").HandlerFunc(gz(httpTraceHdrs(adminAPI.VerifyTierHandler)))
 		// Tier stats
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier-stats").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.TierStatsHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier-stats").HandlerFunc(gz(httpTraceHdrs(adminAPI.TierStatsHandler)))
 
 		// Cluster Replication APIs
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/add").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationAdd))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/remove").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationRemove))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/info").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationInfo))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/metainfo").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationMetaInfo))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/status").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationStatus))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/add").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationAdd)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/remove").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationRemove)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/info").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationInfo)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/metainfo").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationMetaInfo)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/status").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationStatus)))
 
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/join").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerJoin))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/site-replication/peer/bucket-ops").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerBucketOps)))).
-			Queries("bucket", "{bucket:.*}").Queries("operation", "{operation:.*}")
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/iam-item").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerReplicateIAMItem))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/bucket-meta").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerReplicateBucketItem))))
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/peer/idp-settings").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerGetIDPSettings))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/edit").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SiteReplicationEdit))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/edit").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerEdit))))
-		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/remove").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.SRPeerRemove))))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/join").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerJoin)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion+"/site-replication/peer/bucket-ops").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerBucketOps))).Queries("bucket", "{bucket:.*}").Queries("operation", "{operation:.*}")
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/iam-item").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerReplicateIAMItem)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/bucket-meta").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerReplicateBucketItem)))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/site-replication/peer/idp-settings").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerGetIDPSettings)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/edit").HandlerFunc(gz(httpTraceHdrs(adminAPI.SiteReplicationEdit)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/edit").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerEdit)))
+		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/site-replication/peer/remove").HandlerFunc(gz(httpTraceHdrs(adminAPI.SRPeerRemove)))
 
 		if globalIsDistErasure {
 			// Top locks
-			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/top/locks").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.TopLocksHandler))))
+			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/top/locks").HandlerFunc(gz(httpTraceHdrs(adminAPI.TopLocksHandler)))
 			// Force unlocks paths
 			adminRouter.Methods(http.MethodPost).Path(adminVersion+"/force-unlock").
-				Queries("paths", "{paths:.*}").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.ForceUnlockHandler))))
+				Queries("paths", "{paths:.*}").HandlerFunc(gz(httpTraceHdrs(adminAPI.ForceUnlockHandler)))
 		}
 
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.SpeedTestHandler)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.ObjectSpeedTestHandler)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/drive").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.DriveSpeedtestHandler)))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/net").
-			HandlerFunc(adminApiHostHandler(httpTraceHdrs(adminAPI.NetperfHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").HandlerFunc(httpTraceHdrs(adminAPI.SpeedTestHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").HandlerFunc(httpTraceHdrs(adminAPI.ObjectSpeedTestHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/drive").HandlerFunc(httpTraceHdrs(adminAPI.DriveSpeedtestHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/net").HandlerFunc(httpTraceHdrs(adminAPI.NetperfHandler))
 
 		// HTTP Trace
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/trace").
-			HandlerFunc(adminApiHostHandler(gz(http.HandlerFunc(adminAPI.TraceHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/trace").HandlerFunc(gz(http.HandlerFunc(adminAPI.TraceHandler)))
 
 		// Console Logs
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/log").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.ConsoleLogHandler))))
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/log").HandlerFunc(gz(httpTraceAll(adminAPI.ConsoleLogHandler)))
 
 		// -- KMS APIs --
 		//
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/kms/status").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSStatusHandler))))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/kms/key/create").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSCreateKeyHandler)))).
-			Queries("key-id", "{key-id:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/kms/key/status").
-			HandlerFunc(adminApiHostHandler(gz(httpTraceAll(adminAPI.KMSKeyStatusHandler))))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/kms/status").HandlerFunc(gz(httpTraceAll(adminAPI.KMSStatusHandler)))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion+"/kms/key/create").HandlerFunc(gz(httpTraceAll(adminAPI.KMSCreateKeyHandler))).Queries("key-id", "{key-id:.*}")
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/kms/key/status").HandlerFunc(gz(httpTraceAll(adminAPI.KMSKeyStatusHandler)))
 
 		if !globalIsGateway {
 			// Keep obdinfo for backward compatibility with mc
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/obdinfo").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.HealthInfoHandler))))
+				HandlerFunc(gz(httpTraceHdrs(adminAPI.HealthInfoHandler)))
 			// -- Health API --
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/healthinfo").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.HealthInfoHandler))))
+				HandlerFunc(gz(httpTraceHdrs(adminAPI.HealthInfoHandler)))
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/bandwidth").
-				HandlerFunc(adminApiHostHandler(gz(httpTraceHdrs(adminAPI.BandwidthMonitorHandler))))
+				HandlerFunc(gz(httpTraceHdrs(adminAPI.BandwidthMonitorHandler)))
 		}
 	}
+
+	adminRouter.Use(adminApiHostHandler)
 
 	// If none of the routes match add default error handler routes
 	adminRouter.NotFoundHandler = httpTraceAll(errorResponseHandler)

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -403,6 +403,10 @@ func gatewayHandleEnvVars() {
 		}
 		globalPanFSDefaultBucketPath = path
 
+		panOnlyLocalAdminApi := env.Get("MINIO_PANFS_ONLY_LOCAL_ADMIN_API", "1")
+		if panOnlyLocalAdminApi == "0" {
+			globalPanOnlyLocalAdminApi = false
+		}
 	}
 }
 

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -403,9 +403,9 @@ func gatewayHandleEnvVars() {
 		}
 		globalPanFSDefaultBucketPath = path
 
-		panOnlyLocalAdminApi := env.Get("MINIO_PANFS_ONLY_LOCAL_ADMIN_API", "1")
-		if panOnlyLocalAdminApi == "0" {
-			globalPanOnlyLocalAdminApi = false
+		panFSOnlyLocalAdminApi := env.Get("MINIO_PANFS_ONLY_LOCAL_ADMIN_API", "1")
+		if panFSOnlyLocalAdminApi == "0" {
+			globalPanFSOnlyLocalAdminApi = false
 		}
 	}
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -159,6 +159,9 @@ var (
 	// Default path to the bucket in PanFS. Only for PanFS gateway mode
 	globalPanFSDefaultBucketPath = ""
 
+	// Allow Admin API endpoints only from localhost. Only for PanFS gateway mode
+	globalPanOnlyLocalAdminApi = true
+
 	// This flag is set to 'true' by default
 	globalBrowserEnabled = true
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -160,7 +160,7 @@ var (
 	globalPanFSDefaultBucketPath = ""
 
 	// Allow Admin API endpoints only from localhost. Only for PanFS gateway mode
-	globalPanOnlyLocalAdminApi = true
+	globalPanFSOnlyLocalAdminApi = true
 
 	// This flag is set to 'true' by default
 	globalBrowserEnabled = true


### PR DESCRIPTION
Allow access to Admin  APIs only from localhost

## Description

It has been added functionality fo allowing access to Admin APIs only from localhost by default for gateway panfs mode

## Motivation and Context

We MAY want to setup Peer and Admin APIs to allow access only from local interface. Of course, they require root credentials which a customer will not have, so it should not be possible to perform any actions unless someone breaks our encryption. But anyways, this may be a good practice to disallow access to endpoints and APIs that we does not support or does not want to be available outside.

## How to test this PR?

From remote host

```bash
anatolk@> mc alias set mypanfs_2 http://10.75.51.11:9000  minio minio123
Added `mypanfs_2` successfully.
anatolk@> mc admin user list mypanfs_2
mc: <ERROR> Unable to list user. Admin API allowed from localhost only by default.
anatolk@> mc admin info mypanfs_2
mc: <ERROR> Unable to get service status. Admin API allowed from localhost only by default.
```

From local host

```bash
4832d03d21c286# mc alias set mypanfs_l http://localhost:9000 minio minio123
Added `mypanfs_l` successfully.
4832d03d21c286# mc admin info mypanfs_l
●  localhost:9000
   Uptime: 1 minute
   Version: <development>

4832d03d21c286# mc admin user list mypanfs_l
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
