### PR TITLE
Move temporary object uploads to path relative to the new PanFS bucket

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1182,7 +1182,14 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 	// so that cleaning it up will be easy if the server goes down.
 	tempObj := mustGetUUID()
 
-	fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
+	var fsTmpObjPath string
+	// This is to handle bucket metadata which is still using .minio.sys
+	if bucket != minioMetaBucket {
+		fsTmpObjPath = pathJoin(bucketDir, panfsMetaDir, "tmp", fs.fsUUID, tempObj)
+	} else {
+		fsTmpObjPath = pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
+	}
+	// fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
 	bytesWritten, err := fsCreateFile(ctx, fsTmpObjPath, data, data.Size())
 
 	// Delete the temporary object in the case of a

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1189,7 +1189,6 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 	} else {
 		fsTmpObjPath = pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
 	}
-	// fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
 	bytesWritten, err := fsCreateFile(ctx, fsTmpObjPath, data, data.Size())
 
 	// Delete the temporary object in the case of a

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -55,6 +55,7 @@ var PANdefaultEtag = "00000000000000000000000000000000-2"
 const (
 	panfsMetaDir   = ".s3"
 	objMetadataDir = "metadata"
+	tmpDir         = "tmp"
 )
 
 // PANFSObjects - Implements panfs object layer.
@@ -512,9 +513,14 @@ func (fs *PANFSObjects) MakeBucketWithLocation(ctx context.Context, bucket strin
 		return toObjectErr(err, bucket)
 	}
 
-	// Creates dir for object metadata for current bucket
-	objectMetadataPath := pathJoin(opts.PanFSBucketPath, bucket, panfsMetaDir, objMetadataDir)
-	if err := mkdirAll(objectMetadataPath, 0o777); err != nil {
+	bucketMetaDir := pathJoin(opts.PanFSBucketPath, bucket, panfsMetaDir)
+	// Create dir for object metadata
+	if err := mkdirAll(pathJoin(bucketMetaDir, objMetadataDir), 0o777); err != nil {
+		return toObjectErr(err, bucket)
+	}
+
+	// Create dir for temporary uploads
+	if err := mkdirAll(pathJoin(bucketMetaDir, tmpDir), 0o777); err != nil {
 		return toObjectErr(err, bucket)
 	}
 

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1191,7 +1191,7 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 	var fsTmpObjPath string
 	// This is to handle bucket metadata which is still using .minio.sys
 	if bucket != minioMetaBucket {
-		fsTmpObjPath = pathJoin(bucketDir, panfsMetaDir, "tmp", fs.fsUUID, tempObj)
+		fsTmpObjPath = pathJoin(bucketDir, panfsMetaDir, tmpDir, fs.fsUUID, tempObj)
 	} else {
 		fsTmpObjPath = pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, tempObj)
 	}


### PR DESCRIPTION
## Description

This changes moves temporary objects to the new location - relatively to the panfs bucket path. That means that instead of storing objects to the `./minio.sys/tmp/<object>/panfs.json` these objects will be stored into the `/path/to/bucket/.s3/tmp/<object>/panfs.json` and then renamed to the target location

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
