### PR TITLE
[BUGFIX] Attempt to delete existing user results in rather confusing message

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1294,10 +1294,10 @@ func (fs *PANFSObjects) DeleteObject(ctx context.Context, bucket, object string,
 	var rwlk *lock.LockedFile
 
 	var bucketPanfsDir string
-	// DeleteObject operation now also handles the configuration objects. Configuration agent will handle such kind of
-	// operation (e.g. user/policy/group ops) and then panfs backed only will be responsible for object (real data)
-	// operations. At the moment we need to check whether the target bucket is the minio system bucket which stores
-	// all config files.
+	// DeleteObject operation at the moment handles the configuration objects. Configuration agent will handle such
+	// kind of operations (e.g. user/policy/group ops) and then panfs backend only will be responsible for object
+	//(real data) operations. At the moment we need to check whether the target bucket is the minio system bucket which
+	//stores all config files.
 	// TODO: remove this if..else block when config agent will be here
 	if bucket != minioMetaBucket {
 		bucketPanfsDir, err = fs.getBucketPanFSPathFromMeta(ctx, bucket)

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1293,7 +1293,17 @@ func (fs *PANFSObjects) DeleteObject(ctx context.Context, bucket, object string,
 
 	var rwlk *lock.LockedFile
 
-	bucketPanfsDir, err := fs.getBucketPanFSPathFromMeta(ctx, bucket)
+	var bucketPanfsDir string
+	// DeleteObject operation now also handles the configuration objects. Configuration agent will handle such kind of
+	// operation (e.g. user/policy/group ops) and then panfs backed only will be responsible for object (real data)
+	// operations. At the moment we need to check whether the target bucket is the minio system bucket which stores
+	// all config files.
+	// TODO: remove this if..else block when config agent will be here
+	if bucket != minioMetaBucket {
+		bucketPanfsDir, err = fs.getBucketPanFSPathFromMeta(ctx, bucket)
+	} else {
+		bucketPanfsDir, err = fs.getBucketDir(ctx, bucket)
+	}
 	if err != nil {
 		return objInfo, toObjectErr(err, bucket)
 	}


### PR DESCRIPTION
## Description

Attempt to delete existing user results in rather confusing message: "The specified bucket does not exist (Bucket not found: .minio.sys)"

There is no check for `.minio.sys` bucket in delete object handler. At the moment the PanFS backend is still handling either configuration related operations (e.g. user/policy add/delete), and regular object operations. Handling all kind of configuration files will be moved to the configuration agent. 

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
