### PR TITLE
SG-331 Integrate Panasas config agent support

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -609,7 +609,7 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 		if errors.Is(reducedErr, errErasureReadQuorum) && !strings.HasPrefix(bucket, minioMetaBucket) {
 			_, derr := er.deleteIfDangling(ctx, bucket, object, metaArr, errs, nil, opts)
 			if derr != nil {
-				err = derr
+				reducedErr = derr
 			}
 		}
 		return fi, nil, nil, toObjectErr(reducedErr, bucket, object)

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	panconfig "github.com/minio/minio/cmd/panasas/config"
 )
 
 // Converts underlying storage error. Convenience function written to
@@ -97,6 +99,8 @@ func toObjectErr(err error, params ...string) error {
 		}
 		return apiErr
 	case errFileNotFound.Error():
+		fallthrough
+	case panconfig.ErrNotFound.Error():
 		apiErr := ObjectNotFound{}
 		if len(params) >= 1 {
 			apiErr.Bucket = params[0]

--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,11 +9,14 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"path"
+	"strings"
 )
 
-const panasasHTTPS3PrefixHeader string = "x-panasas-s3-prefix"
-const panasasHTTPS3MetadataHeader string = "x-panasas-s3-metadata"
-const panasasHTTPS3ConfigRevisionHeader string = "x-panasas-s3-config-revision"
+const (
+	panasasHTTPS3PrefixHeader   string = "x-panasas-s3-prefix"
+	panasasHTTPS3MetadataHeader string = "Panasas-Config-Object-Metadata"
+)
 
 // ErrNotFound informs that the requested object has not been found by the
 // config agent.
@@ -41,48 +45,52 @@ func (e ErrUnexpectedContentType) Error() string {
 	return fmt.Sprintf("Unexpected HTTP content type: %q", string(e))
 }
 
-// PanasasConfigClient represents a Panasas config agent client
-type PanasasConfigClient struct {
-	agentHost  string
-	agentPort  uint
-	httpClient *http.Client
-	protocol   string
+// Client represents a Panasas config agent client
+type Client struct {
+	agentURL  string
+	namespace string
 
+	httpClient     *http.Client
 	configRevision *string
 }
 
-// NewPanasasConfigClient returns a configured PanasasConfigClient
-func NewPanasasConfigClient(host string, port uint) *PanasasConfigClient {
-	client := PanasasConfigClient{
-		agentHost:  host,
-		agentPort:  port,
+// NewClient returns a configured Client
+func NewClient(agentURL, namespace string) *Client {
+	if agentURL == "" {
+		return nil
+	}
+	client := Client{
+		agentURL:   agentURL,
+		namespace:  namespace,
 		httpClient: &http.Client{},
-		protocol:   "http",
 	}
 	return &client
 }
 
-func (c *PanasasConfigClient) getPanasasConfigStoreURL(base string, elem ...string) (*url.URL, error) {
-	var path string = base
-	var e error
+func (c *Client) getConfigAgentURL(elem ...string) (*url.URL, error) {
+	elems := make([]string, 0, 2+len(elem))
+	elems = append(elems, "namespaces", c.namespace)
+	elems = append(elems, elem...)
 
-	for _, eachElem := range elem {
-		path, e = url.JoinPath(base, url.PathEscape(eachElem))
-		if e != nil {
-			return nil, e
-		}
+	urlPath := path.Join(elems...)
+
+	slash := "/"
+	separator := slash
+	offset := 0
+	for strings.HasPrefix(urlPath[offset:], slash) {
+		offset++
+	}
+	if strings.HasSuffix(c.agentURL, slash) {
+		separator = ""
 	}
 
-	return url.Parse(
-		fmt.Sprintf("%v://%v:%v%v", c.protocol, c.agentHost, c.agentPort, path),
-	)
+	return url.Parse(strings.Join([]string{c.agentURL, urlPath[offset:]}, separator))
 }
 
-func (c *PanasasConfigClient) makePanasasConfigAgentRequest(urlBase string, urlElem ...string) (*http.Request, error) {
-	u, err := c.getPanasasConfigStoreURL(urlBase, urlElem...)
+func (c *Client) makeConfigAgentRequest(urlElem ...string) (*http.Request, error) {
+	u, err := c.getConfigAgentURL(urlElem...)
 	if err != nil {
-		fmt.Printf("Failed formatting URL for %v\n", urlBase)
-		log.Fatal(err)
+		log.Printf("Failed formatting URL for %v: %s\n", urlElem, err)
 		return nil, err
 	}
 
@@ -97,14 +105,6 @@ func (c *PanasasConfigClient) makePanasasConfigAgentRequest(urlBase string, urlE
 		ContentLength: 0,
 	}
 	return &req, nil
-}
-
-func (c *PanasasConfigClient) extractConfigRevision(resp *http.Response) {
-	revisionHeaders := resp.Header.Values(panasasHTTPS3ConfigRevisionHeader)
-	if len(revisionHeaders) > 0 {
-		var revision string = revisionHeaders[0]
-		c.configRevision = &revision
-	}
 }
 
 // closeResponseBody close non nil response with any response Body.
@@ -128,42 +128,45 @@ func closeResponseBody(resp *http.Response) {
 	}
 }
 
-// PanasasObjectList represents a list of objects as returned by configuration agent
-type PanasasObjectList struct {
-	Objects []string
-}
-
 // GetObjectsList returns a list of objects
-func (c *PanasasConfigClient) GetObjectsList(prefix string) ([]string, error) {
-	req, err := c.makePanasasConfigAgentRequest("/objects")
+func (c *Client) GetObjectsList(prefix string) ([]string, error) {
+	req, err := c.makeConfigAgentRequest("configs")
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for /objects with prefix %q\n", prefix)
-		log.Fatal(err)
+		log.Printf("Failed preparing HTTP request object for /objects with prefix %q: %s\n", prefix, err)
 		return []string{}, err
 	}
 
 	req.Header.Set(panasasHTTPS3PrefixHeader, prefix)
 
 	resp, err := c.httpClient.Do(req)
-	defer closeResponseBody(resp)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("HTTP request failed: %s\n", err)
 		return []string{}, err
 	}
-	if contentType := resp.Header.Get("content-type"); contentType != "application/json" {
+	defer closeResponseBody(resp)
+	expectedContentType := "application/json"
+	contentType := resp.Header.Get("content-type")
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = contentType[:idx]
+	}
+	if contentType != expectedContentType {
 		return []string{}, ErrUnexpectedContentType(contentType)
 	}
 
-	dec := json.NewDecoder(resp.Body)
-	var result PanasasObjectList
-	err = dec.Decode(&result)
-
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Reading response body failed with error: %s\n", err)
 		return []string{}, err
 	}
 
-	return result.Objects, nil
+	dec := json.NewDecoder(resp.Body)
+	var result []string
+	err = dec.Decode(&result)
+	if err != nil {
+		log.Printf("JSON decoding failed: %s\n", err)
+		return []string{}, err
+	}
+
+	return result, nil
 }
 
 // GetObject returns an object:
@@ -172,19 +175,18 @@ func (c *PanasasConfigClient) GetObjectsList(prefix string) ([]string, error) {
 // The caller is responsible for calling Close() on the dataReader.
 // If err is not nil, dataReader and metadata are assumed invalid and should
 // not be used.
-func (c *PanasasConfigClient) GetObject(objectName string) (dataReader io.ReadCloser, metadata string, err error) {
-	base := "/objects"
+func (c *Client) GetObject(objectName string) (dataReader io.ReadCloser, oi *ObjectInfo, err error) {
+	base := "configs"
 
-	req, err := c.makePanasasConfigAgentRequest(base, objectName)
+	req, err := c.makeConfigAgentRequest(base, objectName)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, objectName)
-		log.Fatal(err)
-		return nil, "", err
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
+		return nil, nil, err
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("HTTP request failed with error %w", err)
+		return nil, nil, fmt.Errorf("HTTP request failed with error %w", err)
 	}
 
 	defer func() {
@@ -194,31 +196,46 @@ func (c *PanasasConfigClient) GetObject(objectName string) (dataReader io.ReadCl
 	}()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, "", ErrNotFound
+		return nil, nil, ErrNotFound
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, "", ErrUnexpectedHTTPStatus(resp.StatusCode)
+		return nil, nil, ErrUnexpectedHTTPStatus(resp.StatusCode)
 	}
 
-	if contentType := resp.Header.Get("content-type"); contentType != "application/octet-stream" {
+	expectedContentType := "application/octet-stream"
+	contentType := resp.Header.Get("content-type")
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = contentType[:idx]
+	}
+	if contentType != expectedContentType {
 		err = ErrUnexpectedContentType(contentType)
 		return
 	}
 
-	metadata = resp.Header.Get(panasasHTTPS3MetadataHeader)
+	metadata := resp.Header.Get(panasasHTTPS3MetadataHeader)
+	oi, err = parseObjectInfo(metadata)
 
-	return resp.Body, metadata, nil
+	if err != nil {
+		log.Printf(
+			"Failed parsing object info for %v from metadata %q: %s\n",
+			objectName,
+			metadata,
+			err,
+		)
+		return nil, nil, err
+	}
+
+	return resp.Body, oi, nil
 }
 
 // DeleteObject requests an object to be deleted from the config agent
-func (c *PanasasConfigClient) DeleteObject(objectName string, lockID ...string) error {
-	base := "/objects"
+func (c *Client) DeleteObject(objectName string, lockID ...string) error {
+	base := "configs"
 
-	req, err := c.makePanasasConfigAgentRequest(base, objectName)
+	req, err := c.makeConfigAgentRequest(base, objectName)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, objectName)
-		log.Fatal(err)
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return err
 	}
 
@@ -242,32 +259,37 @@ func (c *PanasasConfigClient) DeleteObject(objectName string, lockID ...string) 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return ErrUnexpectedHTTPStatus(resp.StatusCode)
 	}
-	c.extractConfigRevision(resp)
 
+	var ni NamespaceInfo
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&ni)
+	if err != nil {
+		return fmt.Errorf("Cannot decode namespace info - JSON decoding error: %w", err)
+	}
+
+	revision := ni.Revision
+	c.configRevision = &revision
 	return nil
 }
 
 // PutObject stores an object of a given name in the config agent
-func (c *PanasasConfigClient) PutObject(objectName string, data io.Reader, metadata string, lockID ...string) (created bool, e error) {
-	// TODO: set the modification time:
-	// internal/rest/client.go:206:
-	// req.Header.Set("X-Minio-Time", time.Now().UTC().Format(time.RFC3339))
+func (c *Client) PutObject(objectName string, data io.Reader, lockID ...string) error {
+	base := "configs"
 
-	base := "/objects"
-
-	req, err := c.makePanasasConfigAgentRequest(base, objectName)
+	req, err := c.makeConfigAgentRequest(base, objectName)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, objectName)
-		log.Fatal(err)
-		return false, err
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
+		return err
 	}
 
+	if data == nil {
+		data = bytes.NewBuffer([]byte{})
+	}
 	body := io.NopCloser(data)
 
 	req.Method = http.MethodPut
 	req.Body = body
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set(panasasHTTPS3MetadataHeader, metadata)
 
 	if len(lockID) != 0 && lockID[0] != "" {
 		q := req.URL.Query()
@@ -277,90 +299,145 @@ func (c *PanasasConfigClient) PutObject(objectName string, data io.Reader, metad
 	}
 
 	resp, err := c.httpClient.Do(req)
-	closeResponseBody(resp)
+	defer closeResponseBody(resp)
 	if err != nil {
-		return false, fmt.Errorf("HTTP request failed with error %w", err)
-	}
-	if resp.StatusCode == http.StatusOK {
-		c.extractConfigRevision(resp)
-		return false, nil
-	} else if resp.StatusCode == http.StatusCreated {
-		c.extractConfigRevision(resp)
-		return true, nil
+		return fmt.Errorf("HTTP request failed with error %w", err)
 	}
 
-	return false, ErrUnexpectedHTTPStatus(resp.StatusCode)
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		var oi ObjectInfo
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&oi)
+		if err != nil {
+			return fmt.Errorf("Cannot decode namespace info - JSON decoding error: %w", err)
+		}
+
+		revision := oi.Namespace.Revision
+		c.configRevision = &revision
+		return nil
+	}
+
+	return ErrUnexpectedHTTPStatus(resp.StatusCode)
 }
 
 // GetObjectInfo fetches object metadata from the config agent
-func (c *PanasasConfigClient) GetObjectInfo(objectName string) (metadata string, err error) {
-	base := "/objects"
+func (c *Client) GetObjectInfo(objectName string) (oi *ObjectInfo, err error) {
+	base := "configs"
 
-	req, err := c.makePanasasConfigAgentRequest(base, objectName)
+	req, err := c.makeConfigAgentRequest(base, objectName)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, objectName)
-		log.Fatal(err)
-		return "", err
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
+		return nil, err
 	}
 
 	req.Method = http.MethodHead
 	resp, err := c.httpClient.Do(req)
 	closeResponseBody(resp)
 	if err != nil {
-		return "", fmt.Errorf("HTTP request failed with error %w", err)
+		return nil, fmt.Errorf("HTTP request failed with error %w", err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		return "", ErrNotFound
+		return nil, ErrNotFound
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", ErrUnexpectedHTTPStatus(resp.StatusCode)
+		return nil, ErrUnexpectedHTTPStatus(resp.StatusCode)
 	}
 
-	metadata = resp.Header.Get(panasasHTTPS3MetadataHeader)
+	metadata := resp.Header.Get(panasasHTTPS3MetadataHeader)
+	oi, err = parseObjectInfo(metadata)
+	if err != nil {
+		log.Printf(
+			"Failed parsing object info for %v from metadata %q: %s\n",
+			objectName,
+			metadata,
+			err,
+		)
+		return nil, err
+	}
 
-	return metadata, nil
+	return oi, nil
 }
 
 // GetRecentConfigRevision returns the config revision reported by the most
 // recent config modifying operation (PutObject/DeleteObject)
-func (c *PanasasConfigClient) GetRecentConfigRevision() (revision string, err error) {
+func (c *Client) GetRecentConfigRevision() (revision string, err error) {
 	if c.configRevision == nil {
 		return "", ErrNoRevisionYet
 	}
 	return *c.configRevision, nil
 }
 
-// GetConfigRevision queries the config agent for the current config revision
-func (c *PanasasConfigClient) GetConfigRevision() (revision string, err error) {
-	req, err := c.makePanasasConfigAgentRequest("/revision")
+func (c *Client) fetchNamespaceInfo(endpoint, httpMethod string) (*NamespaceInfo, error) {
+	req, err := c.makeConfigAgentRequest(endpoint)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for /revision\n")
-		log.Fatal(err)
-		return "", err
+		if endpoint != "" {
+			log.Printf("Failed preparing HTTP request object for /namespaces/%s/%s: %s\n", c.namespace, endpoint, err)
+		} else {
+			log.Printf("Failed preparing HTTP request object for /namespaces/%s: %s\n", c.namespace, err)
+		}
+		return nil, err
 	}
+	req.Method = httpMethod
 
 	resp, err := c.httpClient.Do(req)
-	closeResponseBody(resp)
+	defer closeResponseBody(resp)
 	if err != nil {
-		return "", fmt.Errorf("HTTP request failed with error %w", err)
+		return nil, fmt.Errorf("HTTP request failed with error %w", err)
 	}
+
 	if resp.StatusCode == http.StatusOK {
-		return resp.Header.Get(panasasHTTPS3ConfigRevisionHeader), nil
+		infoData, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return parseNamespaceInfo(string(infoData))
 	}
-	return "", ErrUnexpectedHTTPStatus(resp.StatusCode)
+
+	return nil, ErrUnexpectedHTTPStatus(resp.StatusCode)
+}
+
+// GetConfigRevision queries the config agent for the current config revision
+func (c *Client) GetConfigRevision() (revision string, err error) {
+	endpoint := ""
+	method := http.MethodGet
+
+	info, err := c.fetchNamespaceInfo(endpoint, method)
+	if err != nil {
+		return "", err
+	}
+	rev := info.Revision
+	c.configRevision = &rev
+
+	return rev, nil
+}
+
+// UpdateConfigRevision forces Panasas config agent to generate a new revision
+// string
+func (c *Client) UpdateConfigRevision() (info *NamespaceInfo, err error) {
+	endpoint := "actions/Revision.Update"
+	method := http.MethodPost
+
+	return c.fetchNamespaceInfo(endpoint, method)
+}
+
+// ClearCache triggers Panasas config agent cache purging
+func (c *Client) ClearCache() (info *NamespaceInfo, err error) {
+	endpoint := "actions/Cache.Clear"
+	method := http.MethodPost
+
+	return c.fetchNamespaceInfo(endpoint, method)
 }
 
 // GetObjectLock tries to get a write or read lock on the specified object
 // Set "read" to true to obtain a non-exclusive read lock.
 // Returns the ID of the obtained lock. This ID can be then used in the calls
 // to ReleaseObjectLock(), PutObject(), DeleteObject().
-func (c *PanasasConfigClient) GetObjectLock(objectName string, read bool) (lockID string, err error) {
+func (c *Client) GetObjectLock(objectName string, read bool) (lockID string, err error) {
 	base := "/lock"
 
-	req, err := c.makePanasasConfigAgentRequest(base, objectName)
+	req, err := c.makeConfigAgentRequest(base, objectName)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, objectName)
-		log.Fatal(err)
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return "", err
 	}
 
@@ -386,7 +463,11 @@ func (c *PanasasConfigClient) GetObjectLock(objectName string, read bool) (lockI
 	}
 
 	expectedContentType := "text/plain"
-	if contentType := resp.Header.Get("content-type"); contentType != expectedContentType{
+	contentType := resp.Header.Get("content-type")
+	if idx := strings.Index(contentType, ";"); idx >= 0 {
+		contentType = contentType[:idx]
+	}
+	if contentType != expectedContentType {
 		err = ErrUnexpectedContentType(contentType)
 		return
 	}
@@ -403,12 +484,11 @@ func (c *PanasasConfigClient) GetObjectLock(objectName string, read bool) (lockI
 // ReleaseObjectLock releases a previously obtained object lock
 // Will return ErrNotFound if the specified lock has not been found or the lock
 // has expired since it was obtained.
-func (c *PanasasConfigClient) ReleaseObjectLock(lockID string) (err error) {
+func (c *Client) ReleaseObjectLock(lockID string) (err error) {
 	base := "/locks"
-	req, err := c.makePanasasConfigAgentRequest(base, lockID)
+	req, err := c.makeConfigAgentRequest(base, lockID)
 	if err != nil {
-		fmt.Printf("Failed preparing HTTP request object for %v with name %q\n", base, lockID)
-		log.Fatal(err)
+		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, lockID, err)
 		return err
 	}
 
@@ -429,4 +509,8 @@ func (c *PanasasConfigClient) ReleaseObjectLock(lockID string) (err error) {
 	}
 
 	return nil
+}
+
+func (c *Client) String() string {
+	return fmt.Sprintf("Client(URL: %q, NS: %q)", c.agentURL, c.namespace)
 }

--- a/cmd/panasas/config/client_test.go
+++ b/cmd/panasas/config/client_test.go
@@ -2,25 +2,28 @@ package config
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 )
 
-var testHost string = "192.168.56.1"
-var testPort uint = 5000
+const (
+	testAgentURL        string = "http://192.168.56.1:8081"
+	testConfigNamespace string = "s3"
+)
 
-
-func TestWriteLocks(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteLocks(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	testObjectName1 := "test_write_lock/object/name"
 	lockID1, err := pc.GetObjectLock(testObjectName1, false)
-
 	if err != nil {
 		t.Fatalf("Failed getting lock for object %q: %v.\n", testObjectName1, err)
 	}
 
-	if len(lockID1) <= 0 {
+	if len(lockID1) == 0 {
 		t.Errorf("Got invalid lock ID %q for object %q.\n", lockID1, testObjectName1)
 	}
 
@@ -76,7 +79,6 @@ func TestWriteLocks(t *testing.T) {
 	}
 
 	lockID1b, err := pc.GetObjectLock(testObjectName1, false)
-
 	if err != nil {
 		t.Fatalf("Failed getting lock for object %q after releasing the previous lock %q: %v.\n", testObjectName1, lockID1, err)
 	}
@@ -86,27 +88,27 @@ func TestWriteLocks(t *testing.T) {
 	}
 }
 
-func TestReadLocks(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyReadLocks(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	testObjectName1 := "test_read_lock/object/name"
 	lockID1, err := pc.GetObjectLock(testObjectName1, true)
-
 	if err != nil {
 		t.Fatalf("Failed getting lock for object %q: %v.\n", testObjectName1, err)
 	}
 
-	if len(lockID1) <= 0 {
+	if len(lockID1) == 0 {
 		t.Errorf("Got invalid lock ID %q for object %q.\n", lockID1, testObjectName1)
 	}
 
 	var locks [10]string
-	for idx := range(locks) {
+	for idx := range locks {
 		newLockID, err := pc.GetObjectLock(testObjectName1, true)
 		if err != nil {
 			t.Fatalf(
 				"Failed getting %v-th read lock for object %q (first lock %q): %v.\n",
-				idx + 2,
+				idx+2,
 				testObjectName1,
 				lockID1,
 				err,
@@ -115,7 +117,7 @@ func TestReadLocks(t *testing.T) {
 		locks[idx] = newLockID
 	}
 
-	for _, lockID := range(locks) {
+	for _, lockID := range locks {
 		if err = pc.ReleaseObjectLock(lockID); err != nil {
 			t.Errorf("Releasing read lock %q failed: %v.\n", lockID, err)
 		}
@@ -140,14 +142,15 @@ func TestReadLocks(t *testing.T) {
 	}
 }
 
-func TestReadLocksWithWriteLock(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyReadLocksWithWriteLock(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	testObjectName1 := "test_read_lock_with_write_lock/object/name"
 	writeLockID, _ := pc.GetObjectLock(testObjectName1, false)
 
 	var locks [10]string
-	for range(locks) {
+	for range locks {
 		readLockID, err := pc.GetObjectLock(testObjectName1, true)
 		if err == nil {
 			t.Fatalf(
@@ -161,7 +164,7 @@ func TestReadLocksWithWriteLock(t *testing.T) {
 
 	pc.ReleaseObjectLock(writeLockID)
 
-	for idx := range(locks) {
+	for idx := range locks {
 		readLockID, err := pc.GetObjectLock(testObjectName1, true)
 		if err != nil {
 			t.Fatalf(
@@ -172,25 +175,26 @@ func TestReadLocksWithWriteLock(t *testing.T) {
 		}
 		locks[idx] = readLockID
 	}
-	for _, lockID := range(locks) {
+	for _, lockID := range locks {
 		pc.ReleaseObjectLock(lockID)
 	}
 }
 
-// TestWriteLockWithReadLock – verify that you can only get a write lock when
+// verifyWriteLockWithReadLock – verify that you can only get a write lock when
 // all the read locks have been released.
-func TestWriteLockWithReadLock(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteLockWithReadLock(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	testObjectName1 := "test_write_lock_with_read_lock/object/name"
 	var locks [10]string
 
-	for idx := range(locks) {
+	for idx := range locks {
 		newLockID, _ := pc.GetObjectLock(testObjectName1, true)
 		locks[idx] = newLockID
 	}
 
-	for _, readLockID := range(locks) {
+	for _, readLockID := range locks {
 		writeLockID, err := pc.GetObjectLock(testObjectName1, false)
 		if err == nil {
 			t.Fatalf(
@@ -215,17 +219,18 @@ func TestWriteLockWithReadLock(t *testing.T) {
 	pc.ReleaseObjectLock(writeLockID)
 }
 
-// TestWriteLockExpiration – verify that write locks are automatically released
+// verifyWriteLockExpiration – verify that write locks are automatically released
 // after some time.
-func TestWriteLockExpiration(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteLockExpiration(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/lock/expiration/object"
 
 	lockID, _ := pc.GetObjectLock(objectName, false)
 
 	// Verify that expiring write lock does not interfere with write locks:
-	time.Sleep(time.Duration(int(0.9 * float64(LockExpirationMilliseconds))) * time.Millisecond)
+	time.Sleep(time.Duration(int(0.9*float64(LockExpirationMilliseconds))) * time.Millisecond)
 	// The lock should still be in place
 	writeLockID, err := pc.GetObjectLock(objectName, false)
 	if err == nil {
@@ -236,7 +241,7 @@ func TestWriteLockExpiration(t *testing.T) {
 			lockID,
 		)
 	}
-	time.Sleep(time.Duration(int(0.2 * float64(LockExpirationMilliseconds))) * time.Millisecond)
+	time.Sleep(time.Duration(int(0.2*float64(LockExpirationMilliseconds))) * time.Millisecond)
 
 	// The original write lock should be automatically released after so much time
 	writeLockID, err = pc.GetObjectLock(objectName, false)
@@ -259,7 +264,7 @@ func TestWriteLockExpiration(t *testing.T) {
 	lockID, _ = pc.GetObjectLock(objectName, false)
 
 	// Verify that expiring write lock does not interfere with read locks:
-	time.Sleep(time.Duration(int(0.9 * float64(LockExpirationMilliseconds))) * time.Millisecond)
+	time.Sleep(time.Duration(int(0.9*float64(LockExpirationMilliseconds))) * time.Millisecond)
 
 	// The lock should still be in place
 	readLockID, err := pc.GetObjectLock(objectName, true)
@@ -271,7 +276,7 @@ func TestWriteLockExpiration(t *testing.T) {
 			lockID,
 		)
 	}
-	time.Sleep(time.Duration(int(0.2 * float64(LockExpirationMilliseconds))) * time.Millisecond)
+	time.Sleep(time.Duration(int(0.2*float64(LockExpirationMilliseconds))) * time.Millisecond)
 
 	// The original write lock should be automatically released after so much time
 	readLockID, err = pc.GetObjectLock(objectName, true)
@@ -290,12 +295,11 @@ func TestWriteLockExpiration(t *testing.T) {
 			err,
 		)
 	}
-
-
 }
 
-func TestReadLockExpiration(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyReadLockExpiration(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_read/lock/expiration/object"
 	locks := [10]string{}
@@ -307,7 +311,7 @@ func TestReadLockExpiration(t *testing.T) {
 		locks[idx] = lockID
 		_, err = pc.GetObjectLock(objectName, false)
 		if err == nil {
-			t.Fatalf("Got write lock on object %q with %v read locks in place.\n", objectName, idx + 1)
+			t.Fatalf("Got write lock on object %q with %v read locks in place.\n", objectName, idx+1)
 		}
 		time.Sleep(time.Duration(LockExpirationMilliseconds) * time.Millisecond / time.Duration(len(locks)))
 	}
@@ -335,7 +339,7 @@ func TestReadLockExpiration(t *testing.T) {
 	for _, lockID := range locks {
 		err = pc.ReleaseObjectLock(lockID)
 		if err == nil {
-			t.Errorf("Releasing expired lock %q for object %q succeded but expected failure.\n", lockID, objectName)
+			t.Errorf("Releasing expired lock %q for object %q succeeded but expected failure.\n", lockID, objectName)
 		} else if err != ErrNotFound {
 			t.Errorf("Got unexpected error while releasing expired lock %q for object %q: %v.\n", lockID, objectName, err)
 		}
@@ -344,8 +348,9 @@ func TestReadLockExpiration(t *testing.T) {
 	pc.ReleaseObjectLock(writeLockID)
 }
 
-func TestWriteOfReadLockedObject(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteOfReadLockedObject(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/of/read/locked/object"
 
@@ -353,7 +358,7 @@ func TestWriteOfReadLockedObject(t *testing.T) {
 
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
-	_, err := pc.PutObject(objectName, data, metadata)
+	err := pc.PutObject(objectName, data, metadata)
 
 	if err == nil {
 		t.Fatalf(
@@ -368,8 +373,9 @@ func TestWriteOfReadLockedObject(t *testing.T) {
 
 // TestWriteAfterReadLockExpires – verify that it is possible to perform
 // PutObject after a read lock has expired
-func TestWriteAfterReadLockExpires(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteAfterReadLockExpires(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/after/read/lock/expired"
 
@@ -379,13 +385,11 @@ func TestWriteAfterReadLockExpires(t *testing.T) {
 		time.Duration(int64(duration)) * time.Millisecond,
 	)
 
-
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
 
-	_ :<- writeLockExpired
-	_, err := pc.PutObject(objectName, data, metadata)
-
+	<-writeLockExpired
+	err := pc.PutObject(objectName, data, metadata)
 	if err != nil {
 		t.Fatalf(
 			"Writing of write-locked object %q failed but write lock %q should have expired.",
@@ -399,8 +403,9 @@ func TestWriteAfterReadLockExpires(t *testing.T) {
 
 // TestWriteOfWriteLockedObject – verify that PutObject calls are rejected
 // while a write lock is in effect
-func TestWriteOfWriteLockedObject(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteOfWriteLockedObject(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_incorrect/write/of/write/locked/object"
 
@@ -408,7 +413,7 @@ func TestWriteOfWriteLockedObject(t *testing.T) {
 
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
-	_, err := pc.PutObject(objectName, data, metadata)
+	err := pc.PutObject(objectName, data, metadata)
 
 	if err == nil {
 		t.Fatalf(
@@ -423,8 +428,9 @@ func TestWriteOfWriteLockedObject(t *testing.T) {
 
 // TestWriteAfterWriteLockExpires – verify that it is possible to perform
 // PutObject after a write lock has expired
-func TestWriteAfterWriteLockExpires(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteAfterWriteLockExpires(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/after/write/lock/expired"
 
@@ -437,9 +443,8 @@ func TestWriteAfterWriteLockExpires(t *testing.T) {
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
 
-	_ :<- writeLockExpired
-	_, err := pc.PutObject(objectName, data, metadata)
-
+	<-writeLockExpired
+	err := pc.PutObject(objectName, data, metadata)
 	if err != nil {
 		t.Fatalf(
 			"Writing of write-locked object %q failed but write lock %q should have expired: %v.",
@@ -453,8 +458,9 @@ func TestWriteAfterWriteLockExpires(t *testing.T) {
 	pc.DeleteObject(objectName)
 }
 
-func TestWriteWithCorrectLockID(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteWithCorrectLockID(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/locked/object/with/correct/lock/id"
 
@@ -463,8 +469,7 @@ func TestWriteWithCorrectLockID(t *testing.T) {
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
 
-	_, err := pc.PutObject(objectName, data, metadata, lockID)
-
+	err := pc.PutObject(objectName, data, metadata, lockID)
 	if err != nil {
 		t.Fatalf(
 			"Writing of write-locked object %q failed although correct lock ID %q provided: %v",
@@ -478,8 +483,9 @@ func TestWriteWithCorrectLockID(t *testing.T) {
 	pc.DeleteObject(objectName)
 }
 
-func TestWriteWithIncorrectLockID(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyWriteWithIncorrectLockID(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_write/locked/object/with/incorrect/lock/id"
 
@@ -489,11 +495,11 @@ func TestWriteWithIncorrectLockID(t *testing.T) {
 	data := bytes.NewReader([]byte("this is some dummy object data"))
 	metadata := "some metadata"
 
-	_, err := pc.PutObject(objectName, data, metadata, incorrectLockID)
+	err := pc.PutObject(objectName, data, metadata, incorrectLockID)
 
 	if err == nil {
 		t.Fatalf(
-			"Writing of write-locked object %q succeded although incorrect lock ID %q provided (correct lock ID: %q).",
+			"Writing of write-locked object %q succeeded although incorrect lock ID %q provided (correct lock ID: %q).",
 			objectName,
 			incorrectLockID,
 			lockID,
@@ -504,17 +510,18 @@ func TestWriteWithIncorrectLockID(t *testing.T) {
 	pc.DeleteObject(objectName)
 }
 
-func TestDeleteWriteLockedObject(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyDeleteWriteLockedObject(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_delete/of/write/locked/object"
 	data := bytes.NewReader([]byte("some dummy data for " + objectName))
 	metadata := "some metadata for " + objectName
-	_, err := pc.PutObject(objectName, data, metadata)
+	pc.PutObject(objectName, data, metadata)
 
 	lockID, _ := pc.GetObjectLock(objectName, false)
 
-	err = pc.DeleteObject(objectName)
+	err := pc.DeleteObject(objectName)
 	if err == nil {
 		t.Fatalf(
 			"Successful deletion of object %q with write lock %q in place but expected failure.",
@@ -537,19 +544,19 @@ func TestDeleteWriteLockedObject(t *testing.T) {
 	pc.DeleteObject(objectName)
 }
 
-func TestDeleteReadLockedObject(t *testing.T) {
-	pc := NewPanasasConfigClient(testHost, testPort)
+func verifyDeleteReadLockedObject(t *testing.T) {
+	t.Skip()
+	pc := NewClient(testAgentURL, testConfigNamespace)
 
 	objectName := "test_delete/of/read/locked/object"
 	data := bytes.NewReader([]byte("some dummy data for " + objectName))
 	metadata := "some metadata for " + objectName
-	_, err := pc.PutObject(objectName, data, metadata)
+	pc.PutObject(objectName, data, metadata)
 
 	lockID, _ := pc.GetObjectLock(objectName, true)
 
-	err = pc.DeleteObject(objectName)
+	err := pc.DeleteObject(objectName)
 	if err == nil {
-
 		t.Fatalf(
 			"Successful deletion of object %q with read lock %q in place but expected failure.",
 			objectName,
@@ -575,5 +582,607 @@ func TestDeleteReadLockedObject(t *testing.T) {
 			lockID,
 			err,
 		)
+	}
+}
+
+// Remove objects with a given prefix from the Panasas config agent
+func removeObjects(t *testing.T, pc *Client, prefix string) {
+	names, err := pc.GetObjectsList(prefix)
+	if err != nil {
+		t.Fatalf("GetObjectsList(%q) returned error: %v", prefix, err)
+	}
+	for _, name := range names {
+		pc.DeleteObject(name)
+	}
+}
+
+// Search for first occurrence of "needle" in the "haystack". Return its index if found, -1 if not.
+func stringIndex(needle string, haystack []string) int {
+	for index, item := range haystack {
+		if needle == item {
+			return index
+		}
+	}
+	return -1
+}
+
+// Performs a check of timestamps: start <= tested <= end
+// Must ensure: start <= end
+func timestampWithinRange(tested, start, end time.Time) bool {
+	if tested.After(start) {
+		return tested.Before(end) || tested.Equal(end)
+	}
+	return tested.Equal(start)
+}
+
+// Test with prefix ending with a slash
+func verifyGetObjectsList1(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	prefix := "test/prefix/test1/"
+	removeObjects(t, pc, prefix)
+	objectNames, err := pc.GetObjectsList(prefix)
+	if err != nil {
+		t.Fatalf("GetObjectsList(%q) returned error: %v", prefix, err)
+	}
+	if len(objectNames) != 0 {
+		t.Fatalf(
+			"Got %v object names from GetObjectsList(%q) although all matching objects have been deleted: %v",
+			len(objectNames),
+			prefix,
+			objectNames,
+		)
+	}
+	suffixes := []string{
+		"foo",
+		"bar",
+		"baz",
+		"quux/foo",
+		"quux/bar",
+		"quux/baz",
+	}
+	for _, suffix := range suffixes {
+		pc.PutObject(prefix+suffix, bytes.NewBuffer([]byte{}))
+	}
+	objectNames, err = pc.GetObjectsList(prefix)
+	if err != nil {
+		t.Fatalf("GetObjectsList(%q) returned error: %v", prefix, err)
+	}
+
+	for _, suffix := range suffixes {
+		expectedObjectName := prefix + suffix
+		if idx := stringIndex(expectedObjectName, objectNames); idx < 0 {
+			t.Fatalf(
+				"GetObjectsList(%q): object %q not found among %v",
+				prefix,
+				expectedObjectName,
+				objectNames,
+			)
+		}
+	}
+	removeObjects(t, pc, prefix)
+}
+
+// Test with prefix without a trailing slash
+func verifyGetObjectsList2(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	prefix := "test/prefix/test2"
+	removeObjects(t, pc, prefix)
+	objectNames, err := pc.GetObjectsList(prefix)
+	if err != nil {
+		t.Fatalf("GetObjectsList(%q) returned error: %v", prefix, err)
+	}
+	if len(objectNames) != 0 {
+		t.Fatalf(
+			"Got %v object names from GetObjectsList(%q) although all matching objects have been deleted: %v",
+			len(objectNames),
+			prefix,
+			objectNames,
+		)
+	}
+	suffixes := []string{
+		"foo",
+		"bar",
+		"baz",
+		"/foo/bar",
+		"/foo/baz",
+		"/foo/quux",
+	}
+	for _, suffix := range suffixes {
+		pc.PutObject(prefix+suffix, bytes.NewBuffer([]byte{}))
+	}
+	objectNames, err = pc.GetObjectsList(prefix)
+	if err != nil {
+		t.Fatalf("GetObjectsList(%q) returned error: %v", prefix, err)
+	}
+
+	for _, suffix := range suffixes {
+		expectedObjectName := prefix + suffix
+		if idx := stringIndex(expectedObjectName, objectNames); idx < 0 {
+			t.Fatalf(
+				"GetObjectsList(%q): object %q not found among %v",
+				prefix,
+				expectedObjectName,
+				objectNames,
+			)
+		}
+	}
+	removeObjects(t, pc, prefix)
+}
+
+// Test GetObject() for a non-existent object
+func verifyGetObject1(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	objectName := "test/getObject/test1/name"
+
+	_, _, err := pc.GetObject(objectName)
+
+	if err == ErrNotFound {
+		// OK - as expected
+	} else if err == nil {
+		t.Fatalf("GetObject(%q) succeeded although the object should not exist", objectName)
+	} else {
+		t.Fatalf("Unexpected error returned from GetObject(%q): %v", objectName, err)
+	}
+}
+
+// Test GetObject()
+func verifyGetObject2(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	objectName := "test/getObject/test2/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+	objectName2 := "test/getObject/test2/name_2"
+	sentData2 := []byte("<data>" + objectName2 + "</data>")
+
+	objectTS1 := time.Now()
+	pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	objectTS2 := time.Now()
+
+	namespaceTS1 := time.Now()
+	pc.PutObject(objectName2, bytes.NewBuffer(sentData2))
+	namespaceTS2 := time.Now()
+
+	r, oi, err := pc.GetObject(objectName)
+	defer r.Close()
+
+	if err != nil {
+		t.Fatalf("GetObject(%q) returned unexpected error: %v", objectName, err)
+	}
+
+	receivedData, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Reading reader returned by GetObject(%q) returned error: %v", objectName, err)
+	}
+	if bytes.Compare(receivedData, sentData) != 0 {
+		t.Fatalf("GetObject(%q) returned incorrect data. Expected %v, got %v", objectName, sentData, receivedData)
+	}
+	if oi.ID != objectName {
+		t.Fatalf("GetObject(%q) returned invalid object info. Expected ID %q, got %q", objectName, objectName, oi.ID)
+	}
+
+	if oi.Namespace.ID != testConfigNamespace {
+		t.Fatalf("GetObject(%q) returned invalid object info. Expected namespace %q, got %q", objectName, testConfigNamespace, oi.Namespace.ID)
+	}
+	revision, err := pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	if revision != oi.Namespace.Revision {
+		t.Fatalf("GetObject(%q) return invalid object info. Expected namespace revision %q, got %q", objectName, revision, oi.Namespace.Revision)
+	}
+
+	timestamp := oi.Namespace.Timestamp
+
+	if !timestampWithinRange(timestamp, namespaceTS1, namespaceTS2) {
+		t.Fatalf(
+			"GetObject(%q): got namespace timestamp out of expected range [%v - %v]: %v",
+			objectName,
+			namespaceTS1,
+			namespaceTS2,
+			timestamp,
+		)
+	}
+
+	timestamp = oi.ChangedAt
+	if !timestampWithinRange(timestamp, objectTS1, objectTS2) {
+		t.Fatalf(
+			"GetObject(%q): got object timestamp out of expected range [%v - %v]: %v",
+			objectName,
+			objectTS1,
+			objectTS2,
+			timestamp,
+		)
+	}
+
+	pc.DeleteObject(objectName)
+}
+
+// verifyDeleteObject1 - test deletion of non-existent object
+func verifyDeleteObject1(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	objectName := "test/deleteObject/test1/name"
+	err := pc.DeleteObject(objectName)
+	if err != ErrNotFound {
+		if err != nil {
+			t.Fatalf("DeleteObject(%q) returned unexpected error: %s", objectName, err)
+		} else {
+			t.Fatalf("DeleteObject(%q) unexpectedly succeeded. Expected error: %s", objectName, ErrNotFound)
+		}
+	}
+}
+
+// verifyDeleteObject2 - test deletion of existing object
+func verifyDeleteObject2(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	objectName := "test/deleteObject/test2/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+
+	err := pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	if err != nil {
+		t.Fatalf("PutObject(%q) failed with error: %s", objectName, err)
+	}
+
+	err = pc.DeleteObject(objectName)
+	if err != nil {
+		t.Fatalf("DeleteObject(%q) returned unexpected error: %s", objectName, err)
+	}
+
+	_, _, err = pc.GetObject(objectName)
+	if err != ErrNotFound {
+		if err != nil {
+			t.Fatalf("GetObject(%q) returned unexpected error for deleted object: %s", objectName, err)
+		} else {
+			t.Fatalf("GetObject(%q) unexpectedly succeeded for deleted object. Expected error: %s", objectName, ErrNotFound)
+		}
+	}
+
+	_, err = pc.GetObjectInfo(objectName)
+	if err != ErrNotFound {
+		if err != nil {
+			t.Fatalf("GetObjectInfo(%q) returned unexpected error for deleted object: %s", objectName, err)
+		} else {
+			t.Fatalf("GetObjectInfo(%q) unexpectedly succeeded for deleted object. Expected error: %s", objectName, ErrNotFound)
+		}
+	}
+
+	err = pc.DeleteObject(objectName)
+	if err != ErrNotFound {
+		if err != nil {
+			t.Fatalf("DeleteObject(%q) returned unexpected error: %s", objectName, err)
+		} else {
+			t.Fatalf("DeleteObject(%q) unexpectedly succeeded. Expected error: %s", objectName, ErrNotFound)
+		}
+	}
+}
+
+// verifyPutObject - test PutObject
+func verifyPutObject(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	objectName := "test/pubObject/test1/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+	err := pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	if err != nil {
+		t.Fatalf("PutObject(%q) failed: %s", objectName, err)
+	}
+
+	pc.DeleteObject(objectName)
+}
+
+// verifyPutExistingObject - test PutObject
+func verifyPutExistingObject(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	objectName := "test/pubObject/test2/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+
+	err := pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	if err != nil {
+		t.Fatalf("PutObject(%q) failed: %s", objectName, err)
+	}
+
+	sentData = []byte("<data2>" + objectName + "</data2>")
+	err = pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	if err != nil {
+		t.Fatalf("PutObject(%q) for existing object failed: %s", objectName, err)
+	}
+
+	pc.DeleteObject(objectName)
+}
+
+// verifyGetObjectInfo1 - test GetObjectInfo() for an existing object
+func verifyGetObjectInfo1(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	objectName := "test/getObjectInfo/test1/name"
+	_, err := pc.GetObjectInfo(objectName)
+	if err != ErrNotFound {
+		if err == nil {
+			t.Fatalf("GetObjectInfo(%q) unexpectedly succeeded. Expected %s", objectName, ErrNotFound)
+		} else {
+			t.Fatalf("GetObjectInfo(%q) returned unexpected error: %s", objectName, err)
+		}
+	}
+}
+
+// Test GetObjectInfo() for an existing object
+func verifyGetObjectInfo2(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	objectName := "test/getObjectInfo/test2/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+
+	ts1 := time.Now()
+	pc.PutObject(objectName, bytes.NewBuffer(sentData))
+	ts2 := time.Now()
+
+	oi, err := pc.GetObjectInfo(objectName)
+	if err != nil {
+		t.Fatalf("GetObjectInfo(%q) failed with error: %s", objectName, err)
+	}
+
+	if oi.ID != objectName {
+		t.Fatalf("GetObjectInfo(%q) returned incorrect ID: expected %q, got %q", objectName, objectName, oi.ID)
+	}
+	if !timestampWithinRange(oi.ChangedAt, ts1, ts2) {
+		t.Fatalf(
+			"GetObjectInfo(%q): got object timestamp out of expected range [%v - %v]: %v",
+			objectName,
+			ts1,
+			ts2,
+			oi.ChangedAt,
+		)
+	}
+	if oi.ByteLength != int64(len(sentData)) {
+		t.Fatalf("GetObjectInfo(%q): got incorrect object size. Expected %v, got %v", objectName, len(sentData), oi.ByteLength)
+	}
+
+	expectedRevision, _ := pc.GetRecentConfigRevision()
+	if expectedRevision != oi.Namespace.Revision {
+		t.Fatalf("GetObjectInfo(%q): got wrong config revision. Expected %q, got %q", objectName, expectedRevision, oi.Namespace.Revision)
+	}
+	if testConfigNamespace != oi.Namespace.ID {
+		t.Fatalf("GetObjectInfo(%q): got wrong config namespace ID. Expected %q, got %q", objectName, testConfigNamespace, oi.Namespace.ID)
+	}
+	if !timestampWithinRange(oi.Namespace.Timestamp, ts1, ts2) {
+		t.Fatalf(
+			"GetObjectInfo(%q): got namespace timestamp out of expected range [%v - %v]: %v",
+			objectName,
+			ts1,
+			ts2,
+			oi.Namespace.Timestamp,
+		)
+	}
+
+	pc.DeleteObject(objectName)
+}
+
+// verifyGetRecentConfigRevision - test GetRecentConfigRevision() and GetConfigRevision()
+func verifyGetRecentConfigRevision(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+	_, err := pc.GetRecentConfigRevision()
+	if err != ErrNoRevisionYet {
+		if err == nil {
+			t.Fatalf("GetRecentConfigRevision() unexpectedly succeeded for newly created config agent client")
+		} else {
+			t.Fatalf("GetRecentConfigRevision() returned unexpected error for newly created config client: %s", err)
+		}
+	}
+	objectName := "test/getRecentConfigRevision/test1/name"
+	sentData := []byte("<data>" + objectName + "</data>")
+	pc.PutObject(objectName, bytes.NewBuffer(sentData))
+
+	rev, err := pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+
+	objectName2 := "test/getRecentConfigRevision/test2/name"
+	sentData2 := []byte("<data>" + objectName2 + "</data>")
+	pc.PutObject(objectName2, bytes.NewBuffer(sentData2))
+
+	newRev, err := pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	if newRev == rev {
+		t.Fatalf("GetRecentConfigRevision() returned same revision %q after 2 consecutive PutObject() calls", rev)
+	}
+	rev = newRev
+
+	pc.DeleteObject(objectName)
+
+	newRev, err = pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	// DeleteObject() should cause a new revision to be saved
+	if newRev == rev {
+		t.Fatalf("GetRecentConfigRevision() returned old revision %q after DeleteObject()", rev)
+	}
+	rev = newRev
+
+	// Force a new config revision to be created on the agent through a new
+	// client. The old client should not be aware of the new revision until
+	// it is forced to fetch it by a call to GetConfigRevision().
+	pc2 := NewClient(testAgentURL, testConfigNamespace)
+	ni, _ := pc2.UpdateConfigRevision()
+
+	newRev, err = pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	// Should not be aware of new revision:
+	if newRev != rev {
+		t.Fatalf("GetRecentConfigRevision() returned new revision %q but expected old one %q", newRev, rev)
+	}
+
+	// Force the client to fetch the new revision:
+	newRev, err = pc.GetConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	if rev == newRev {
+		t.Fatalf("GetConfigRevision() returned old revision %q but a new one was expected", rev)
+	}
+	if newRev != ni.Revision {
+		t.Fatalf("GetConfigRevision() returned revision %q but expected revision matching %q returned previously by UpdateConfigRevision", newRev, ni.Revision)
+	}
+	oldRev := rev
+	rev = newRev
+
+	// Should be aware of the new revision:
+	newRev, err = pc.GetRecentConfigRevision()
+	if err != nil {
+		t.Fatalf("GetRecentConfigRevision() returned unexpected error: %s", err)
+	}
+	if newRev != rev {
+		t.Fatalf(
+			"GetRecentConfigRevision() returned unexpected revision. Old: %q, current: %q, expected: %q",
+			oldRev,
+			newRev,
+			rev,
+		)
+	}
+
+	pc.DeleteObject(objectName2)
+}
+
+func verifyUpdateConfigRevision(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	oldRevision, err := pc.GetConfigRevision()
+	if err != nil {
+		t.Fatalf("Getting config revision failed with error: %s", err)
+	}
+	ts1 := time.Now()
+	ni, err := pc.UpdateConfigRevision()
+	ts2 := time.Now()
+	if err != nil {
+		t.Fatalf("UpdateConfigRevision() returned error: %s", err)
+	}
+	if ni.ID != testConfigNamespace {
+		t.Fatalf("UpdateConfigRevision() return ID %q, expected %q", ni.ID, testConfigNamespace)
+	}
+	if ni.Revision == oldRevision {
+		t.Fatalf("UpdateConfigRevision() returned revision equal to old")
+	}
+	timestamp := ni.Timestamp
+	if !timestampWithinRange(timestamp, ts1, ts2) {
+		t.Fatalf("UpdateConfigRevision() timestamp out of expected range of [%v - %v]: %v", ts1, ts2, timestamp)
+	}
+
+	newRevision, err := pc.GetConfigRevision()
+	if err != nil {
+		t.Fatalf("Getting config revision failed with error: %s", err)
+	}
+
+	if newRevision == oldRevision {
+		t.Fatalf("UpdateConfigRevision() called but config revision remained %q", oldRevision)
+	}
+}
+
+func verifyClearCache(t *testing.T) {
+	pc := NewClient(testAgentURL, testConfigNamespace)
+
+	ni1, _ := pc.UpdateConfigRevision()
+
+	ni2, err := pc.ClearCache()
+	if err != nil {
+		t.Fatalf("ClearCache() failed with error: %s", err)
+	}
+	if ni1.ID != ni2.ID || ni1.ID != testConfigNamespace {
+		t.Fatalf("ClearCache() expected namespace ID %q, got: %q", testConfigNamespace, ni2.ID)
+	}
+	if ni1.Revision != ni2.Revision {
+		t.Fatalf("ClearCache() expected config revision %q, got: %q", ni1.Revision, ni2.Revision)
+	}
+	if !ni1.Timestamp.Equal(ni2.Timestamp) {
+		t.Fatalf("ClearCache() expected config timestamp %q, got: %q", ni1.Timestamp, ni2.Timestamp)
+	}
+}
+
+func TestNetworkedFunctionality(t *testing.T) {
+	t.Skip()
+	t.Run("verifyWriteLocks", verifyWriteLocks)
+	t.Run("verifyReadLocks", verifyReadLocks)
+	t.Run("verifyReadLocksWithWriteLock", verifyReadLocksWithWriteLock)
+	t.Run("verifyWriteLockWithReadLock", verifyWriteLockWithReadLock)
+	t.Run("verifyWriteLockExpiration", verifyWriteLockExpiration)
+	t.Run("verifyReadLockExpiration", verifyReadLockExpiration)
+	t.Run("verifyWriteOfReadLockedObject", verifyWriteOfReadLockedObject)
+	t.Run("verifyWriteAfterReadLockExpires", verifyWriteAfterReadLockExpires)
+	t.Run("verifyWriteOfWriteLockedObject", verifyWriteOfWriteLockedObject)
+	t.Run("verifyWriteAfterWriteLockExpires", verifyWriteAfterWriteLockExpires)
+	t.Run("verifyWriteWithCorrectLockID", verifyWriteWithCorrectLockID)
+	t.Run("verifyWriteWithIncorrectLockID", verifyWriteWithIncorrectLockID)
+	t.Run("verifyDeleteWriteLockedObject", verifyDeleteWriteLockedObject)
+	t.Run("verifyDeleteReadLockedObject", verifyDeleteReadLockedObject)
+	t.Run("verifyGetObjectsList1", verifyGetObjectsList1)
+	t.Run("verifyGetObjectsList2", verifyGetObjectsList2)
+	t.Run("verifyGetObject1", verifyGetObject1)
+	t.Run("verifyGetObject2", verifyGetObject2)
+	t.Run("verifyDeleteObject1", verifyDeleteObject1)
+	t.Run("verifyDeleteObject2", verifyDeleteObject2)
+	t.Run("verifyPutObject", verifyPutObject)
+	t.Run("verifyPutExistingObject", verifyPutExistingObject)
+	t.Run("verifyGetObjectInfo1", verifyGetObjectInfo1)
+	t.Run("verifyGetObjectInfo2", verifyGetObjectInfo2)
+	t.Run("verifyGetRecentConfigRevision", verifyGetRecentConfigRevision)
+	t.Run("verifyGetRecentConfigRevision", verifyGetRecentConfigRevision)
+	t.Run("verifyUpdateConfigRevision", verifyUpdateConfigRevision)
+	t.Run("verifyClearCache", verifyClearCache)
+}
+
+func performURLTest(t *testing.T, pc *Client, expected string, parts ...string) {
+	u, err := pc.getConfigAgentURL("foo", "bar", "baz")
+	if err != nil {
+		t.Fatalf("getPanasasConfigStoreURL() returned error: %s", err)
+	}
+
+	result := fmt.Sprint(u)
+	if result != expected {
+		t.Fatalf("URL formatting error. Expected %q, got %q", expected, result)
+	}
+}
+
+func TestConfigStoreUrlFormatting(t *testing.T) {
+	testCases := []struct {
+		expected string
+		elements []string
+	}{
+		{"http://example.com/namespaces/ns1/foo/bar/baz", []string{"foo", "bar", "baz"}},
+		{"http://example.com/namespaces/ns1/foo/bar/baz", []string{"foo/", "bar", "baz"}},
+		{"http://example.com/namespaces/ns1/foo/bar/baz", []string{"foo/", "/bar", "baz"}},
+		{"http://example.com/namespaces/ns1/foo/bar/baz", []string{"foo/", "/bar/", "baz"}},
+		{"http://example.com/namespaces/ns1/foo/bar/baz", []string{"foo/", "/bar/", "baz/"}},
+	}
+
+	initData := []struct {
+		url, ns string
+	}{
+		{"http://example.com", "ns1"},
+		{"http://example.com/", "ns1"},
+		{"http://example.com", "/ns1"},
+		{"http://example.com/", "/ns1"},
+		{"http://example.com", "ns1/"},
+		{"http://example.com/", "ns1/"},
+		{"http://example.com", "/ns1/"},
+		{"http://example.com/", "/ns1/"},
+	}
+	for initIdx := range initData {
+		pc := Client{
+			agentURL:  initData[initIdx].url,
+			namespace: initData[initIdx].ns,
+		}
+		fmt.Printf("pc: %v\n", &pc)
+		for _, testCase := range testCases {
+			t.Run(
+				fmt.Sprintf("performURLTest(t, %v, test case: %q)", &pc, testCase),
+				func(t *testing.T) {
+					performURLTest(t, &pc, testCase.expected, testCase.elements...)
+				},
+			)
+		}
 	}
 }

--- a/cmd/panasas/config/namespace_info.go
+++ b/cmd/panasas/config/namespace_info.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// NamespaceInfo represents information about Panasas config agent namespace
+type NamespaceInfo struct {
+	ID        string    `json:"id"`
+	Revision  string    `json:"revision"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func parseNamespaceInfo(JSONData string) (*NamespaceInfo, error) {
+	var ni NamespaceInfo
+
+	if err := json.Unmarshal([]byte(JSONData), &ni); err != nil {
+		return nil, err
+	}
+	return &ni, nil
+}

--- a/cmd/panasas/config/object_info.go
+++ b/cmd/panasas/config/object_info.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"encoding/json"
+	"io/fs"
+	"time"
+)
+
+// ObjectInfo - object information returned by Panasas config agent
+type ObjectInfo struct {
+	ID         string            `json:"id"`
+	Metadata   map[string]string `json:"metadata"`
+	Namespace  NamespaceInfo     `json:"namespace"`
+	ChangedAt  time.Time         `json:"mod-time"`
+	ByteLength int64             `json:"size"`
+}
+
+// Name - return name of the object
+func (poi *ObjectInfo) Name() string {
+	return poi.ID
+}
+
+// Size - return object's byte length
+func (poi *ObjectInfo) Size() int64 {
+	return poi.ByteLength
+}
+
+// Mode - return the file mode bits for the object. The permissions are not
+// supported so the value will be 0.
+func (poi *ObjectInfo) Mode() fs.FileMode {
+	return fs.FileMode(0)
+}
+
+// ModTime - returns object modification time
+func (poi *ObjectInfo) ModTime() time.Time {
+	return poi.ChangedAt
+}
+
+// IsDir - returns boolean to indicate if the object is a directory
+func (poi *ObjectInfo) IsDir() bool {
+	return false
+}
+
+// Sys - return pointer to some internal data
+func (poi *ObjectInfo) Sys() any {
+	return nil
+}
+
+func parseObjectInfo(JSONData string) (*ObjectInfo, error) {
+	var oi ObjectInfo
+
+	if err := json.Unmarshal([]byte(JSONData), &oi); err != nil {
+		return nil, err
+	}
+	return &oi, nil
+}

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -320,6 +320,13 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 		return n, cr.err
 	}
 	b, err = cr.reader.ReadByte()
+	if err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	if err != nil {
+		cr.err = err
+		return n, cr.err
+	}
 	if b != '\r' {
 		cr.err = errMalformedEncoding
 		return n, cr.err

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -81,5 +81,6 @@ const (
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
 
-	EnvPanFSBucketPath = "MINIO_PANFS_BUCKET_PATH"
+	EnvPanFSBucketPath       = "MINIO_PANFS_BUCKET_PATH"
+	EnvPanasasConfigAgentURL = "MINIO_PANFS_CONFIG_AGENT_URL"
 )


### PR DESCRIPTION
The address of the Panasas config agent is configured by setting the MINIO_PANFS_CONFIG_AGENT_URL env variable to the scheme and authority part of the URL. E.g.:
MINIO_PANFS_CONFIG_AGENT_URL="http://localhost:8081"

Among others the following are stored in the config agent:
- user-related data,
- policies,
- list of buckets.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
