### PR TITLE
SG-158 Store multipart upload files relatively to PanFS volume

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -19,14 +19,15 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
+	"net/netip"
+	"strings"
+
 	"github.com/gorilla/mux"
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/klauspost/compress/gzip"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/logger"
-	"net/http"
-	"net/netip"
-	"strings"
 )
 
 const (
@@ -38,8 +39,8 @@ const (
 // adminAPIHandlers provides HTTP handlers for MinIO admin API.
 type adminAPIHandlers struct{}
 
-// adminApiHostHandler - allow access to the  Admin APIs only from local interface by default.
-func adminApiHostHandler(next http.Handler) http.Handler {
+// adminAPIHostHandler - allow access to the  Admin APIs only from local interface by default.
+func adminAPIHostHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		clientIP := strings.Split(r.RemoteAddr, ":")[0]
 		addr, err := netip.ParseAddr(clientIP)
@@ -306,8 +307,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 		}
 	}
 
-	if globalIsGateway && globalGatewayName == PANFSBackendGateway && globalPanFSOnlyLocalAdminApi {
-		adminRouter.Use(adminApiHostHandler)
+	if globalIsGateway && globalGatewayName == PANFSBackendGateway && globalPanFSOnlyLocalAdminAPI {
+		adminRouter.Use(adminAPIHostHandler)
 	}
 
 	// If none of the routes match add default error handler routes

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -403,9 +403,8 @@ func gatewayHandleEnvVars() {
 		}
 		globalPanFSDefaultBucketPath = path
 
-		panFSOnlyLocalAdminApi := env.Get("MINIO_PANFS_ONLY_LOCAL_ADMIN_API", "1")
-		if panFSOnlyLocalAdminApi == "0" {
-			globalPanFSOnlyLocalAdminApi = false
+		if onlyLocalAdmin := env.Get("MINIO_PANFS_ONLY_LOCAL_ADMIN_API", "1"); onlyLocalAdmin == "0" {
+			globalPanFSOnlyLocalAdminAPI = false
 		}
 	}
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -160,7 +160,7 @@ var (
 	globalPanFSDefaultBucketPath = ""
 
 	// Allow Admin API endpoints only from localhost. Only for PanFS gateway mode
-	globalPanFSOnlyLocalAdminApi = true
+	globalPanFSOnlyLocalAdminAPI = true
 
 	// This flag is set to 'true' by default
 	globalBrowserEnabled = true

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -40,13 +40,13 @@ const (
 	panbgAppendsCleanupInterval = 10 * time.Minute
 )
 
-// Returns EXPORT/bucketPath/.s3/multipart/SHA256/UPLOADID
+// Returns EXPORT/bucket/.s3/multipart/SHA256/UPLOADID
 // TODO: refactoring. Add context to the arguments. Use getBucketPath from metadata. Remove bucketPath argument.
 func (fs *PANFSObjects) getUploadIDDir(bucketPath, bucket, object, uploadID string) string {
 	return pathJoin(bucketPath, panfsS3MultipartDir, getSHA256Hash([]byte(pathJoin(bucket, object))), uploadID)
 }
 
-// Returns EXPORT/.minio.sys/multipart/SHA256
+// Returns EXPORT/bucket/.s3/multipart/SHA256
 // TODO: refactoring. Add context to the arguments. Remove bucketPath argument.
 func (fs *PANFSObjects) getMultipartSHADir(bucketPath, bucket, object string) string {
 	return pathJoin(bucketPath, panfsS3MultipartDir, getSHA256Hash([]byte(pathJoin(bucket, object))))

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -891,7 +891,7 @@ func (fs *PANFSObjects) AbortMultipartUpload(ctx context.Context, bucket, object
 
 	// Purge multipart folders
 	{
-		fsTmpObjPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, mustGetUUID())
+		fsTmpObjPath := pathJoin(bucketPath, panfsS3TmpDir, fs.fsUUID, mustGetUUID())
 		defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
 
 		Rename(uploadIDDir, fsTmpObjPath)

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -41,13 +41,11 @@ const (
 )
 
 // Returns EXPORT/bucket/.s3/multipart/SHA256/UPLOADID
-// TODO: refactoring. Add context to the arguments. Use getBucketPath from metadata. Remove bucketPath argument.
 func (fs *PANFSObjects) getUploadIDDir(bucketPath, bucket, object, uploadID string) string {
 	return pathJoin(bucketPath, panfsS3MultipartDir, getSHA256Hash([]byte(pathJoin(bucket, object))), uploadID)
 }
 
 // Returns EXPORT/bucket/.s3/multipart/SHA256
-// TODO: refactoring. Add context to the arguments. Remove bucketPath argument.
 func (fs *PANFSObjects) getMultipartSHADir(bucketPath, bucket, object string) string {
 	return pathJoin(bucketPath, panfsS3MultipartDir, getSHA256Hash([]byte(pathJoin(bucket, object))))
 }

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -374,9 +374,7 @@ func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploa
 
 	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
 	if err = Rename(tmpPartPath, partPath); err != nil {
-		if err != nil {
-			return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
-		}
+		return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
 	}
 
 	go fs.backgroundAppend(context.Background(), bucket, object, uploadID)

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -376,10 +376,9 @@ func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploa
 
 	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
 	if err = Rename(tmpPartPath, partPath); err != nil {
-		if err == errFileNotFound || err == errFileAccessDenied {
+		if err != nil {
 			return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
 		}
-		return pi, toObjectErr(err, panfsS3MultipartDir, partPath)
 	}
 
 	go fs.backgroundAppend(context.Background(), bucket, object, uploadID)

--- a/cmd/panfs-multipart_test.go
+++ b/cmd/panfs-multipart_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,6 +30,25 @@ import (
 
 	"github.com/minio/minio/internal/config/api"
 )
+
+// initPanFSWithBucket initializes the panfs backend and creates a bucket for testing
+//Fail test when object init or bucket creation will fail
+func initPanFSWithBucket(bucket string, t *testing.T) (obj ObjectLayer, disk string) {
+	disk = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+
+	obj, err := initPanFSObjects(disk)
+	obj = obj.(*PANFSObjects)
+	if err != nil {
+		t.Fatalf("Cannot init PANFS backend: \"%v\"", err)
+	}
+	if bucket != "" {
+		err = obj.MakeBucketWithLocation(GlobalContext, bucket, MakeBucketOptions{PanFSBucketPath: disk})
+		if err != nil {
+			t.Fatalf("Cannot create bucket \"%v\"", err)
+		}
+	}
+	return
+}
 
 // Tests cleanup multipart uploads for filesystem backend.
 func TestPANFSCleanupMultipartUploadsInRoutine(t *testing.T) {
@@ -89,23 +109,15 @@ func TestPANFSCleanupMultipartUploadsInRoutine(t *testing.T) {
 
 // TestNewPANFMultipartUploadFaultyDisk - test NewMultipartUpload with faulty disks
 func TestNewPANFMultipartUploadFaultyDisk(t *testing.T) {
-	t.Skip()
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
-	obj := initFSObjects(disk, t)
-
-	fs := obj.(*PANFSObjects)
-	bucketName := "bucket"
-	objectName := "object"
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	// Test with disk removed.
 	os.RemoveAll(disk)
-	if _, err := fs.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}}); err != nil {
+	if _, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}}); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error ", err)
 		}
@@ -115,18 +127,12 @@ func TestNewPANFMultipartUploadFaultyDisk(t *testing.T) {
 // TestPANFSPutObjectPartFaultyDisk - test PutObjectPart with faulty disks
 func TestPANFSPutObjectPartFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
-	obj := initFSObjects(disk, t)
-
-	bucketName := "bucket"
-	objectName := "object"
 	data := []byte("12345")
 	dataLen := int64(len(data))
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
 	if err != nil {
@@ -136,9 +142,8 @@ func TestPANFSPutObjectPartFaultyDisk(t *testing.T) {
 	md5Hex := getMD5Hash(data)
 	sha256sum := ""
 
-	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	obj, newDisk := initPanFSWithBucket("", t)
 	defer os.RemoveAll(newDisk)
-	obj = initFSObjects(newDisk, t)
 	if _, err = obj.PutObjectPart(GlobalContext, bucketName, objectName, res.UploadID, 1, mustGetPutObjReader(t, bytes.NewReader(data), dataLen, md5Hex, sha256sum), ObjectOptions{}); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error ", err)
@@ -149,17 +154,11 @@ func TestPANFSPutObjectPartFaultyDisk(t *testing.T) {
 // TestPANFSCompleteMultipartUploadFaultyDisk - test CompleteMultipartUpload with faulty disks
 func TestPANFSCompleteMultipartUploadFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
-	obj := initFSObjects(disk, t)
-
-	bucketName := "bucket"
-	objectName := "object"
 	data := []byte("12345")
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
 	if err != nil {
@@ -169,9 +168,8 @@ func TestPANFSCompleteMultipartUploadFaultyDisk(t *testing.T) {
 	md5Hex := getMD5Hash(data)
 
 	parts := []CompletePart{{PartNumber: 1, ETag: md5Hex}}
-	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	obj, newDisk := initPanFSWithBucket("", t)
 	defer os.RemoveAll(newDisk)
-	obj = initFSObjects(newDisk, t)
 	if _, err := obj.CompleteMultipartUpload(GlobalContext, bucketName, objectName, res.UploadID, parts, ObjectOptions{}); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error ", err)
@@ -182,17 +180,12 @@ func TestPANFSCompleteMultipartUploadFaultyDisk(t *testing.T) {
 // TestPANFSCompleteMultipartUpload - test CompleteMultipartUpload
 func TestPANFSCompleteMultipartUpload(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
+
 	defer os.RemoveAll(disk)
-	obj := initFSObjects(disk, t)
-
-	bucketName := "bucket"
-	objectName := "object"
 	data := []byte("12345")
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
 	if err != nil {
@@ -219,17 +212,11 @@ func TestPANFSAbortMultipartUpload(t *testing.T) {
 	}
 
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
-	obj := initFSObjects(disk, t)
-
-	bucketName := "bucket"
-	objectName := "object"
 	data := []byte("12345")
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	res, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
 	if err != nil {
@@ -250,29 +237,91 @@ func TestPANFSAbortMultipartUpload(t *testing.T) {
 // TestPANFSListMultipartUploadsFaultyDisk - test ListMultipartUploads with faulty disks
 func TestPANFSListMultipartUploadsFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
-
-	obj := initFSObjects(disk, t)
-
-	bucketName := "bucket"
-	objectName := "object"
-
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{}); err != nil {
-		t.Fatal("Cannot create bucket, err: ", err)
-	}
 
 	_, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{UserDefined: map[string]string{"X-Amz-Meta-xid": "3f"}})
 	if err != nil {
 		t.Fatal("Unexpected error ", err)
 	}
 
-	newDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	defer os.RemoveAll(newDisk)
-	obj = initFSObjects(newDisk, t)
+	obj, disk = initPanFSWithBucket("", t)
+	defer os.RemoveAll(disk)
 	if _, err := obj.ListMultipartUploads(GlobalContext, bucketName, objectName, "", "", "", 1000); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error ", err)
 		}
 	}
 }
+
+func TestPANFSNewMultipartUpload(t *testing.T) {
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
+	defer os.RemoveAll(disk)
+
+	// Create new multipart upload using not existing bucket
+	nonExistentBucket := "non-existent-bucket"
+	_, err := obj.NewMultipartUpload(GlobalContext, nonExistentBucket, "test-object", ObjectOptions{})
+	if !errors.Is(err, BucketNotFound{Bucket: nonExistentBucket}) {
+		t.Fatalf("Expected error \"%v\" but found \"%v\"", BucketNotFound{Bucket: nonExistentBucket}, err)
+	}
+
+	// Create new multipart upload using valid bucket and object
+	_, err = obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error \"%v\"", err)
+	}
+}
+
+func TestPANFSPutObjectPart(t *testing.T) {
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	contentBytes := []byte("content")
+	sha256 := getSHA256Hash(contentBytes)
+	partNumber := 1
+	obj, disk := initPanFSWithBucket(bucketName, t)
+	defer os.RemoveAll(disk)
+
+	nonExistendUploadID := "nonExistentUploadID"
+	nonExistentBucket := "nonExistentBucket"
+
+	uploadID, err := obj.NewMultipartUpload(GlobalContext, bucketName, objectName, ObjectOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error \"%v\"", err)
+	}
+
+	reader := mustGetPutObjReader(t, bytes.NewReader(contentBytes), int64(len(contentBytes)), "", sha256)
+
+	// Put object part with not existing bucket
+	_, err = obj.PutObjectPart(GlobalContext, nonExistentBucket, objectName, uploadID.UploadID, partNumber, reader, ObjectOptions{})
+	if !errors.Is(err, BucketNotFound{Bucket: nonExistentBucket}) {
+		t.Fatalf("Expected error \"%v\" but found \"%v\"\"", BucketNotFound{Bucket: nonExistentBucket}, err)
+	}
+
+	// Put object part with an uninitialized upload id
+	_, err = obj.PutObjectPart(GlobalContext, bucketName, objectName, nonExistendUploadID, partNumber, reader, ObjectOptions{})
+	expectedErr := InvalidUploadID{Bucket: bucketName, Object: objectName, UploadID: nonExistendUploadID}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("Expected error \"%v\" but found \"%v\"\"", expectedErr, err)
+	}
+
+	// Put object part with valid arguments
+	pi, err := obj.PutObjectPart(GlobalContext, bucketName, objectName, uploadID.UploadID, partNumber, reader, ObjectOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error \"%v\"", err)
+	}
+	if pi.PartNumber != partNumber {
+		t.Fatalf("Expectied part number %v but found %v", partNumber, pi.PartNumber)
+	}
+	expectedSize := int64(len(contentBytes))
+	if pi.Size != expectedSize {
+		t.Fatalf("Expectied size %v but found %v", expectedSize, pi.Size)
+	}
+}
+
+//func TestPANFSCompleteMultipartUpload(t *testing.T) {
+//	t.Skip()
+//}

--- a/cmd/panfs-multipart_test.go
+++ b/cmd/panfs-multipart_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // initPanFSWithBucket initializes the panfs backend and creates a bucket for testing
-//Fail test when object init or bucket creation will fail
+// Fail test when object init or bucket creation will fail
 func initPanFSWithBucket(bucket string, t *testing.T) (obj ObjectLayer, disk string) {
 	disk = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 
@@ -321,7 +321,3 @@ func TestPANFSPutObjectPart(t *testing.T) {
 		t.Fatalf("Expectied size %v but found %v", expectedSize, pi.Size)
 	}
 }
-
-//func TestPANFSCompleteMultipartUpload(t *testing.T) {
-//	t.Skip()
-//}

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -514,8 +514,7 @@ func (fs *PANFSObjects) MakeBucketWithLocation(ctx context.Context, bucket strin
 	}
 
 	// Create dir for temporary uploads
-	metaTmpPath := pathJoin(bucketMetaDir, tmpDir)
-	if err := mkdirAll(metaTmpPath, 0o777); err != nil {
+	if err := mkdirAll(pathJoin(bucketMetaDir, tmpDir), 0o777); err != nil {
 		return toObjectErr(err, bucket)
 	}
 

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -109,7 +109,6 @@ func initMetaVolumePANFS(fsPath, fsUUID string) error {
 	if err := os.MkdirAll(metaBucketPath, 0o777); err != nil {
 		return err
 	}
-	// TODO: remove dir creation at this step. All dirs are created during bucket creation
 	metaTmpPath := pathJoin(fsPath, minioMetaTmpBucket, fsUUID)
 	if err := os.MkdirAll(metaTmpPath, 0o777); err != nil {
 		return err

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1297,8 +1297,8 @@ func (fs *PANFSObjects) DeleteObject(ctx context.Context, bucket, object string,
 	var bucketPanfsDir string
 	// DeleteObject operation at the moment handles the configuration objects. Configuration agent will handle such
 	// kind of operations (e.g. user/policy/group ops) and then panfs backend only will be responsible for object
-	//(real data) operations. At the moment we need to check whether the target bucket is the minio system bucket which
-	//stores all config files.
+	// (real data) operations. At the moment we need to check whether the target bucket is the minio system bucket which
+	// stores all config files.
 	// TODO: remove this if..else block when config agent will be here
 	if bucket != minioMetaBucket {
 		bucketPanfsDir, err = fs.getBucketPanFSPathFromMeta(ctx, bucket)

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -206,39 +206,33 @@ func TestPANFSDeleteObject(t *testing.T) {
 	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
 
-	obj, err := initPanFSObjects(disk)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fs := obj.(*PANFSObjects)
-
 	obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
 	obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{})
 
 	// Test with invalid bucket name
-	if _, err := fs.DeleteObject(GlobalContext, "fo", objectName, ObjectOptions{}); !isSameType(err, BucketNameInvalid{}) {
+	if _, err := obj.DeleteObject(GlobalContext, "fo", objectName, ObjectOptions{}); !isSameType(err, BucketNameInvalid{}) {
 		t.Fatal("Unexpected error: ", err)
 	}
 	// Test with bucket does not exist
-	if _, err := fs.DeleteObject(GlobalContext, "foobucket", "fooobject", ObjectOptions{}); !isSameType(err, BucketNotFound{}) {
+	if _, err := obj.DeleteObject(GlobalContext, "foobucket", "fooobject", ObjectOptions{}); !isSameType(err, BucketNotFound{}) {
 		t.Fatal("Unexpected error: ", err)
 	}
 	// Test with invalid object name
-	if _, err := fs.DeleteObject(GlobalContext, bucketName, "\\", ObjectOptions{}); !(isSameType(err, ObjectNotFound{}) || isSameType(err, ObjectNameInvalid{})) {
+	if _, err := obj.DeleteObject(GlobalContext, bucketName, "\\", ObjectOptions{}); !(isSameType(err, ObjectNotFound{}) || isSameType(err, ObjectNameInvalid{})) {
 		t.Fatal("Unexpected error: ", err)
 	}
 	// Test with object does not exist.
-	if _, err := fs.DeleteObject(GlobalContext, bucketName, "foooobject", ObjectOptions{}); !isSameType(err, ObjectNotFound{}) {
+	if _, err := obj.DeleteObject(GlobalContext, bucketName, "foooobject", ObjectOptions{}); !isSameType(err, ObjectNotFound{}) {
 		t.Fatal("Unexpected error: ", err)
 	}
 	// Test with valid condition
-	if _, err := fs.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
+	if _, err := obj.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
 
 	// Delete object should err disk not found.
 	os.RemoveAll(disk)
-	if _, err := fs.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
+	if _, err := obj.DeleteObject(GlobalContext, bucketName, objectName, ObjectOptions{}); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error: ", err)
 		}

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -201,7 +201,9 @@ func TestPANFSPutObject(t *testing.T) {
 // TestPANFSDeleteObject - test fs.DeleteObject() with healthy and corrupted disks
 func TestPANFSDeleteObject(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	bucketName := getRandomBucketName()
+	objectName := getRandomObjectName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	defer os.RemoveAll(disk)
 
 	obj, err := initPanFSObjects(disk)
@@ -209,8 +211,6 @@ func TestPANFSDeleteObject(t *testing.T) {
 		t.Fatal(err)
 	}
 	fs := obj.(*PANFSObjects)
-	bucketName := "bucket"
-	objectName := "object"
 
 	obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{})
 	obj.PutObject(GlobalContext, bucketName, objectName, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), ObjectOptions{})


### PR DESCRIPTION
## Description

Move temporary objects and metadata related to multipart upload to the new bucket location.
The final object is still storing into the standard minio location (e.g. bucket folder in the root location)

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
