### PR TITLE
SG-495 Replace rename with link/unlink

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -364,6 +364,26 @@ func fsRenameFile(ctx context.Context, sourcePath, destPath string) error {
 	return nil
 }
 
+// Renames source path to destination path, creates all the
+// missing parents if they don't exist.
+func panfsRenameFile(ctx context.Context, sourcePath, destPath string) error {
+	if err := checkPathLength(sourcePath); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+	if err := checkPathLength(destPath); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+
+	if err := panRenameAll(sourcePath, destPath); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+
+	return nil
+}
+
 func deleteFile(basePath, deletePath string, recursive bool) error {
 	if basePath == "" || deletePath == "" {
 		return nil

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -376,7 +376,7 @@ func panfsRenameFile(ctx context.Context, sourcePath, destPath string) error {
 		return err
 	}
 
-	if err := panRenameAll(sourcePath, destPath); err != nil {
+	if err := panRenameFileAll(sourcePath, destPath); err != nil {
 		logger.LogIf(ctx, err)
 		return err
 	}

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -137,12 +137,17 @@ func Rename(src, dst string) error {
 // PanRenameFile captures time taken to call Link/Unlink
 func PanRenameFile(src, dst string) error {
 	defer updateOSMetrics(osMetricRename, src, dst)()
-	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	err := os.Link(src, dst)
-	if err != nil {
-		return err
+	if err := os.Link(src, dst); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+		//dst file exists
+		if err = os.Remove(dst); err != nil {
+			return err
+		}
+		if err = os.Link(src, dst); err != nil {
+			return err
+		}
 	}
 	return os.Remove(src)
 }

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -137,11 +137,8 @@ func Rename(src, dst string) error {
 // PanRename captures time taken to call Link/Unlink
 func PanRename(src, dst string) error {
 	defer updateOSMetrics(osMetricRename, src, dst)()
-	if _, err := os.Stat(dst); !os.IsNotExist(err) {
-		err = os.Remove(dst)
-		if err != nil {
-			return err
-		}
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	err := os.Link(src, dst)
 	if err != nil {

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -141,7 +141,7 @@ func PanRenameFile(src, dst string) error {
 		if !os.IsExist(err) {
 			return err
 		}
-		//dst file exists
+		// dst file exists
 		if err = os.Remove(dst); err != nil {
 			return err
 		}

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -134,8 +134,8 @@ func Rename(src, dst string) error {
 	return os.Rename(src, dst)
 }
 
-// PanRename captures time taken to call Link/Unlink
-func PanRename(src, dst string) error {
+// PanRenameFile captures time taken to call Link/Unlink
+func PanRenameFile(src, dst string) error {
 	defer updateOSMetrics(osMetricRename, src, dst)()
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
 		return err

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -134,6 +134,22 @@ func Rename(src, dst string) error {
 	return os.Rename(src, dst)
 }
 
+// PanRename captures time taken to call Link/Unlink
+func PanRename(src, dst string) error {
+	defer updateOSMetrics(osMetricRename, src, dst)()
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		err = os.Remove(dst)
+		if err != nil {
+			return err
+		}
+	}
+	err := os.Link(src, dst)
+	if err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
 // OpenFile captures time taken to call os.OpenFile
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	switch flag & writeMode {

--- a/cmd/os-reliable.go
+++ b/cmd/os-reliable.go
@@ -160,6 +160,50 @@ func renameAll(srcFilePath, dstFilePath string) (err error) {
 	return nil
 }
 
+// Wrapper function to os.Rename, which calls reliableMkdirAll
+// and reliableRenameAll. This is to ensure that if there is a
+// racy parent directory delete in between we can simply retry
+// the operation.
+func panRenameAll(srcFilePath, dstFilePath string) (err error) {
+	if srcFilePath == "" || dstFilePath == "" {
+		return errInvalidArgument
+	}
+
+	if err = checkPathLength(srcFilePath); err != nil {
+		return err
+	}
+	if err = checkPathLength(dstFilePath); err != nil {
+		return err
+	}
+
+	if err = panReliableRename(srcFilePath, dstFilePath); err != nil {
+		switch {
+		case isSysErrNotDir(err) && !osIsNotExist(err):
+			// Windows can have both isSysErrNotDir(err) and osIsNotExist(err) returning
+			// true if the source file path contains an non-existent directory. In that case,
+			// we want to return errFileNotFound instead, which will honored in subsequent
+			// switch cases
+			return errFileAccessDenied
+		case isSysErrPathNotFound(err):
+			// This is a special case should be handled only for
+			// windows, because windows API does not return "not a
+			// directory" error message. Handle this specifically here.
+			return errFileAccessDenied
+		case isSysErrCrossDevice(err):
+			return fmt.Errorf("%w (%s)->(%s)", errCrossDeviceLink, srcFilePath, dstFilePath)
+		case osIsNotExist(err):
+			return errFileNotFound
+		case osIsExist(err):
+			// This is returned only when destination is a directory and we
+			// are attempting a rename from file to directory.
+			return errIsNotRegular
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
 // Reliably retries os.RenameAll if for some reason os.RenameAll returns
 // syscall.ENOENT (parent does not exist).
 func reliableRename(srcFilePath, dstFilePath string) (err error) {
@@ -171,6 +215,28 @@ func reliableRename(srcFilePath, dstFilePath string) (err error) {
 	for {
 		// After a successful parent directory create attempt a renameAll.
 		if err = Rename(srcFilePath, dstFilePath); err != nil {
+			// Retry only for the first retryable error.
+			if osIsNotExist(err) && i == 0 {
+				i++
+				continue
+			}
+		}
+		break
+	}
+	return err
+}
+
+// Reliably retries os.RenameAll if for some reason os.RenameAll returns
+// syscall.ENOENT (parent does not exist).
+func panReliableRename(srcFilePath, dstFilePath string) (err error) {
+	if err = reliableMkdirAll(path.Dir(dstFilePath), 0o777); err != nil {
+		return err
+	}
+
+	i := 0
+	for {
+		// After a successful parent directory create attempt a renameAll.
+		if err = PanRename(srcFilePath, dstFilePath); err != nil {
 			// Retry only for the first retryable error.
 			if osIsNotExist(err) && i == 0 {
 				i++

--- a/cmd/os-reliable.go
+++ b/cmd/os-reliable.go
@@ -164,7 +164,7 @@ func renameAll(srcFilePath, dstFilePath string) (err error) {
 // and reliableRenameAll. This is to ensure that if there is a
 // racy parent directory delete in between we can simply retry
 // the operation.
-func panRenameAll(srcFilePath, dstFilePath string) (err error) {
+func panRenameFileAll(srcFilePath, dstFilePath string) (err error) {
 	if srcFilePath == "" || dstFilePath == "" {
 		return errInvalidArgument
 	}
@@ -176,7 +176,7 @@ func panRenameAll(srcFilePath, dstFilePath string) (err error) {
 		return err
 	}
 
-	if err = panReliableRename(srcFilePath, dstFilePath); err != nil {
+	if err = panReliableRenameFile(srcFilePath, dstFilePath); err != nil {
 		switch {
 		case isSysErrNotDir(err) && !osIsNotExist(err):
 			// Windows can have both isSysErrNotDir(err) and osIsNotExist(err) returning
@@ -228,7 +228,7 @@ func reliableRename(srcFilePath, dstFilePath string) (err error) {
 
 // Reliably retries os.RenameAll if for some reason os.RenameAll returns
 // syscall.ENOENT (parent does not exist).
-func panReliableRename(srcFilePath, dstFilePath string) (err error) {
+func panReliableRenameFile(srcFilePath, dstFilePath string) (err error) {
 	if err = reliableMkdirAll(path.Dir(dstFilePath), 0o777); err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func panReliableRename(srcFilePath, dstFilePath string) (err error) {
 	i := 0
 	for {
 		// After a successful parent directory create attempt a renameAll.
-		if err = PanRename(srcFilePath, dstFilePath); err != nil {
+		if err = PanRenameFile(srcFilePath, dstFilePath); err != nil {
 			// Retry only for the first retryable error.
 			if osIsNotExist(err) && i == 0 {
 				i++

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -381,7 +381,7 @@ func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploa
 	partPath := pathJoin(uploadIDDir, fs.encodePartFile(partID, etag, data.ActualSize()))
 
 	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
-	if err = Rename(tmpPartPath, partPath); err != nil {
+	if err = PanRename(tmpPartPath, partPath); err != nil {
 		return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
 	}
 
@@ -821,7 +821,7 @@ func (fs *PANFSObjects) CompleteMultipartUpload(ctx context.Context, bucket stri
 	}
 
 	// TODO: move to relative position when config agent will be here
-	err = fsRenameFile(ctx, appendFilePath, pathJoin(fs.fsPath, bucket, object))
+	err = panfsRenameFile(ctx, appendFilePath, pathJoin(fs.fsPath, bucket, object))
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return oi, toObjectErr(err, bucket, object)
@@ -893,15 +893,13 @@ func (fs *PANFSObjects) AbortMultipartUpload(ctx context.Context, bucket, object
 	}
 
 	// Purge multipart folders
-	{
-		fsTmpObjPath := pathJoin(bucketPath, panfsS3TmpDir, fs.fsUUID, mustGetUUID())
-		defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
+	fsTmpObjPath := pathJoin(bucketPath, panfsS3TmpDir, fs.fsUUID, mustGetUUID())
+	defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
 
-		Rename(uploadIDDir, fsTmpObjPath)
+	Rename(uploadIDDir, fsTmpObjPath)
 
-		// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
-		fsRemoveDir(ctx, fs.getMultipartSHADir(bucketPath, bucket, object))
-	}
+	// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
+	fsRemoveDir(ctx, fs.getMultipartSHADir(bucketPath, bucket, object))
 
 	return nil
 }

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -380,7 +380,7 @@ func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploa
 	partPath := pathJoin(uploadIDDir, fs.encodePartFile(partID, etag, data.ActualSize()))
 
 	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
-	if err = PanRename(tmpPartPath, partPath); err != nil {
+	if err = PanRenameFile(tmpPartPath, partPath); err != nil {
 		return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
 	}
 

--- a/cmd/panfs-multipart.go
+++ b/cmd/panfs-multipart.go
@@ -373,7 +373,7 @@ func (fs *PANFSObjects) PutObjectPart(ctx context.Context, bucket, object, uploa
 	partPath := pathJoin(uploadIDDir, fs.encodePartFile(partID, etag, data.ActualSize()))
 
 	// Make sure not to create parent directories if they don't exist - the upload might have been aborted.
-	if err = Rename(tmpPartPath, partPath); err != nil {
+	if err = PanRename(tmpPartPath, partPath); err != nil {
 		return pi, InvalidUploadID{Bucket: bucket, Object: object, UploadID: uploadID}
 	}
 
@@ -813,7 +813,7 @@ func (fs *PANFSObjects) CompleteMultipartUpload(ctx context.Context, bucket stri
 	}
 
 	// TODO: move to relative position when config agent will be here
-	err = fsRenameFile(ctx, appendFilePath, pathJoin(fs.fsPath, bucket, object))
+	err = panfsRenameFile(ctx, appendFilePath, pathJoin(fs.fsPath, bucket, object))
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return oi, toObjectErr(err, bucket, object)
@@ -885,15 +885,13 @@ func (fs *PANFSObjects) AbortMultipartUpload(ctx context.Context, bucket, object
 	}
 
 	// Purge multipart folders
-	{
-		fsTmpObjPath := pathJoin(bucketPath, panfsS3TmpDir, fs.fsUUID, mustGetUUID())
-		defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
+	fsTmpObjPath := pathJoin(bucketPath, panfsS3TmpDir, fs.fsUUID, mustGetUUID())
+	defer fsRemoveAll(ctx, fsTmpObjPath) // remove multipart temporary files in background.
 
-		Rename(uploadIDDir, fsTmpObjPath)
+	Rename(uploadIDDir, fsTmpObjPath)
 
-		// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
-		fsRemoveDir(ctx, fs.getMultipartSHADir(bucketPath, bucket, object))
-	}
+	// It is safe to ignore any directory not empty error (in case there were multiple uploadIDs on the same object)
+	fsRemoveDir(ctx, fs.getMultipartSHADir(bucketPath, bucket, object))
 
 	return nil
 }

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1297,7 +1297,7 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 
 		// Entire object was written to the temp location, now it's safe to rename it to the actual location.
 		fsNSObjPath = pathJoin(fs.fsPath, bucket, object)
-		if err = fsRenameFile(ctx, fsTmpObjPath, fsNSObjPath); err != nil {
+		if err = panfsRenameFile(ctx, fsTmpObjPath, fsNSObjPath); err != nil {
 			return ObjectInfo{}, toObjectErr(err, bucket, object)
 		}
 	}

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1323,7 +1323,7 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 
 		// Entire object was written to the temp location, now it's safe to rename it to the actual location.
 		fsNSObjPath = pathJoin(fs.fsPath, bucket, object)
-		if err = fsRenameFile(ctx, fsTmpObjPath, fsNSObjPath); err != nil {
+		if err = panfsRenameFile(ctx, fsTmpObjPath, fsNSObjPath); err != nil {
 			return ObjectInfo{}, toObjectErr(err, bucket, object)
 		}
 	}


### PR DESCRIPTION
## Description
Hard links can be created only for files, so I replaced all renaming of files where we use temp folders.
There are two operations which use renaming of files(one more for multipart): copy and put. Copy operation relies on put operation so we need to change only one of them. 

## Motivation and Context
It can speed up working with metadata

## How to test this PR?
By running unit tests

## Types of changes
- [x] Optimization (provides speedup with no functional changes)

