### PR TITLE
SG-517 awscli test case from minio mint suite failed with "An error occurred (404) when calling the HeadObject operation: Not Found"

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -1570,12 +1570,12 @@ func (fs *PANFSObjects) filterOutPanFSS3Dir(entries []string) (filtered []string
 // isObjectDir returns true if the specified bucket & prefix exists
 // and the prefix represents an empty directory. An S3 empty directory
 // is also an empty directory in the PanFS backend.
-func (fs *PANFSObjects) isObjectDir(bucket, prefix string) bool {
+func (fs *PANFSObjects) isObjectDir(bucketDir, prefix string) bool {
 	if fs.configAgent != nil {
-		entries, err := fs.configAgent.GetObjectsList(pathJoin(panfsObjectsPrefix, bucket, prefix, slashSeparator))
+		entries, err := fs.configAgent.GetObjectsList(pathJoin(panfsObjectsPrefix, bucketDir, prefix, slashSeparator))
 		return err != nil && len(entries) == 0
 	}
-	entries, err := readDirN(pathJoin(fs.fsPath, bucket, prefix), 1)
+	entries, err := readDirN(pathJoin(bucketDir, prefix), 1)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Description

Removed call to the config agent as the function `isObjectDir` is only called when need to define whether the target object is directory or not. This should not affect bucket metadata files (as far as I see).

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
