### PR TITLE
SG-532 Fix minio linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   gofumpt:
-    lang-version: "1.18"
+    lang-version: "1.19"
 
   misspell:
     locale: US

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,10 +7,6 @@ linters-settings:
       - name: unused-parameter
         severity: warning
         disabled: true
-      - name: function-result-limit
-        severity: warning
-        disabled: false
-        arguments: [10]
 
   misspell:
     locale: US

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,16 @@
 linters-settings:
   gofumpt:
     lang-version: "1.19"
+  revive:
+    severity: error
+    rules:
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+      - name: function-result-limit
+        severity: warning
+        disabled: false
+        arguments: [10]
 
   misspell:
     locale: US

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: ## print this help
 
 getdeps: ## fetch necessary dependencies
 	@mkdir -p ${GOPATH}/bin
-	@echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
+	@echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2/install.sh | sh -s -- -b $(GOPATH)/bin
 	@echo "Installing msgp" && go install -v github.com/tinylib/msgp@f3635b96e4838a6c773babb65ef35297fe5fe2f9
 	@echo "Installing stringer" && go install -v golang.org/x/tools/cmd/stringer@latest
 

--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -244,7 +244,7 @@ func testGetBucketPanFSPathHandler(obj ObjectLayer, instanceType, bucketName str
 			secretKey:          credentials.SecretKey,
 			expectedRespStatus: http.StatusOK,
 			panFSResponse: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<PanFSPath>` + globalPanFSDefaultBucketPath + `</PanFSPath>`),
+<PanFSPath>` + pathJoin(globalPanFSDefaultBucketPath, bucketName+"/") + `</PanFSPath>`),
 			errorResponse: APIErrorResponse{},
 			shouldPass:    true,
 		},

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -550,7 +550,7 @@ type RestoreObjectRequest struct {
 	XMLName          xml.Name           `xml:"http://s3.amazonaws.com/doc/2006-03-01/ RestoreRequest" json:"-"`
 	Days             int                `xml:"Days,omitempty"`
 	Type             RestoreRequestType `xml:"Type,omitempty"`
-	Tier             string             `xml:"Tier,-"`
+	Tier             string             `xml:"-"` // `xml:"Tier,-"`
 	Description      string             `xml:"Description,omitempty"`
 	SelectParameters *SelectParameters  `xml:"SelectParameters,omitempty"`
 	OutputLocation   OutputLocation     `xml:"OutputLocation,omitempty"`

--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -207,7 +207,7 @@ func getSetIndexes(args []string, totalSizes []uint64, customSetDriveCount uint6
 }
 
 // Returns all the expanded endpoints, each argument is expanded separately.
-func (s endpointSet) getEndpoints() (endpoints []string) {
+func (s *endpointSet) getEndpoints() (endpoints []string) {
 	if len(s.endpoints) != 0 {
 		return s.endpoints
 	}

--- a/cmd/panfs-multipart_test.go
+++ b/cmd/panfs-multipart_test.go
@@ -41,8 +41,8 @@ func initPanFSWithBucket(bucket string, t *testing.T) (obj ObjectLayer, disk str
 		t.Fatalf("Cannot find user: " + err.Error())
 	}
 
-	os.Setenv(config.EnvPanDefaultOwner, usr.Uid)
-	os.Setenv(config.EnvPanDefaultGroup, usr.Gid)
+	t.Setenv(config.EnvPanDefaultOwner, usr.Uid)
+	t.Setenv(config.EnvPanDefaultGroup, usr.Gid)
 
 	defer func() {
 		if err != nil {

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -198,11 +198,15 @@ func NewPANFSObjectLayer(ctx context.Context, fsPath string) (ObjectLayer, error
 	if err != nil {
 		return nil, fmt.Errorf("can't parse default obj mode Error: %w", err)
 	}
-	defaultOwner, err := strconv.Atoi(env.Get(config.EnvPanDefaultOwner, "0"))
+	usr, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("cannot find user: %w", err)
+	}
+	defaultOwner, err := strconv.Atoi(env.Get(config.EnvPanDefaultOwner, usr.Uid))
 	if err != nil {
 		return nil, fmt.Errorf("can't parse default obj mode Error: %w", err)
 	}
-	defaultGroup, err := strconv.Atoi(env.Get(config.EnvPanDefaultGroup, "0"))
+	defaultGroup, err := strconv.Atoi(env.Get(config.EnvPanDefaultGroup, usr.Gid))
 	if err != nil {
 		return nil, fmt.Errorf("can't parse default obj mode Error: %w", err)
 	}

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -241,19 +241,10 @@ func TestPANFSDeleteBucket(t *testing.T) {
 // TestPANFSListBuckets - tests for fs ListBuckets
 func TestPANFSListBuckets(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	defer os.RemoveAll(disk)
-
-	obj, err := initPanFSObjects(disk)
-	if err != nil {
-		t.Fatal(err)
-	}
+	bucketName := getRandomBucketName()
+	obj, disk := initPanFSWithBucket(bucketName, t)
 	fs := obj.(*PANFSObjects)
-
-	bucketName := "bucket"
-	if err := obj.MakeBucketWithLocation(GlobalContext, bucketName, MakeBucketOptions{PanFSBucketPath: disk}); err != nil {
-		t.Fatal("Unexpected error: ", err)
-	}
+	defer os.RemoveAll(disk)
 
 	// Create a bucket with invalid name
 	if err := os.MkdirAll(pathJoin(fs.fsPath, "vo^"), 0o777); err != nil {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -251,15 +251,7 @@ func initPanFSObjects(fs string) (obj ObjectLayer, err error) {
 
 // Initialize FS objects.
 func initFSObjects(disk string, t *testing.T) (obj ObjectLayer) {
-	usr, err := user.Current()
-	if err != nil {
-		t.Fatalf("Cannot find user: " + err.Error())
-	}
-
-	t.Setenv(config.EnvPanDefaultOwner, usr.Uid)
-	t.Setenv(config.EnvPanDefaultGroup, usr.Gid)
-
-	obj, _, err = initObjectLayer(context.Background(), mustGetPoolEndpoints(disk))
+	obj, _, err := initObjectLayer(context.Background(), mustGetPoolEndpoints(disk))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1605,7 +1597,7 @@ func initAPIHandlerTest(ctx context.Context, obj ObjectLayer, endpoints []string
 	err := obj.MakeBucketWithLocation(context.Background(), bucketName, opts)
 	if err != nil {
 		// failed to create newbucket, return err.
-		return "", nil, err
+		return "", nil, fmt.Errorf("failed to create newbucket: %v", err)
 	}
 	// Register the API end points with Erasure object layer.
 	// Registering only the GetObject handler.
@@ -1863,6 +1855,15 @@ func ExecPanFSObjectLayerAPITest(t *testing.T, objAPITest objAPITestType, endpoi
 	// set globalIsGateway true and globalGatewayName to PANFS
 	globalIsGateway = true
 	globalGatewayName = PANFSBackendGateway
+
+	// Setup default user and group.
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("Cannot find user: " + err.Error())
+	}
+
+	t.Setenv(config.EnvPanDefaultOwner, usr.Uid)
+	t.Setenv(config.EnvPanDefaultGroup, usr.Gid)
 
 	objLayer, fsDir, err := preparePanFS(ctx)
 	globalPanFSDefaultBucketPath = fsDir

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -256,8 +256,8 @@ func initFSObjects(disk string, t *testing.T) (obj ObjectLayer) {
 		t.Fatalf("Cannot find user: " + err.Error())
 	}
 
-	os.Setenv(config.EnvPanDefaultOwner, usr.Uid)
-	os.Setenv(config.EnvPanDefaultGroup, usr.Gid)
+	t.Setenv(config.EnvPanDefaultOwner, usr.Uid)
+	t.Setenv(config.EnvPanDefaultGroup, usr.Gid)
 
 	obj, _, err = initObjectLayer(context.Background(), mustGetPoolEndpoints(disk))
 	if err != nil {


### PR DESCRIPTION
## Description

Set specific version of linter manager (equal to 1.52) to prevent unexpected behavior of linter workflow when golangci-lint will be updated.
Fixed linter errors.
Replaced default user and group bits (which was set by default  to root for all new objects and directories created on the minio side) by user which is running minio proces

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
