### PR TITLE
SG-568: Minio crashing with panic on start

### DIFF
--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -13,10 +13,7 @@ import (
 	"strings"
 )
 
-const (
-	panasasHTTPS3PrefixHeader   string = "x-panasas-s3-prefix"
-	panasasHTTPS3MetadataHeader string = "Panasas-Config-Object-Metadata"
-)
+const panasasHTTPS3MetadataHeader string = "Panasas-Config-Object-Metadata"
 
 // ErrNotFound informs that the requested object has not been found by the
 // config agent.
@@ -136,7 +133,9 @@ func (c *Client) GetObjectsList(prefix string) ([]string, error) {
 		return []string{}, err
 	}
 
-	req.Header.Set(panasasHTTPS3PrefixHeader, prefix)
+	q := req.URL.Query()
+	q.Add("prefix", prefix)
+	req.URL.RawQuery = q.Encode()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -205,7 +204,7 @@ func (c *Client) GetObject(objectName string) (dataReader io.ReadCloser, oi *Obj
 	}
 	if contentType != expectedContentType {
 		err = ErrUnexpectedContentType(contentType)
-		return
+		return nil, nil, err
 	}
 
 	metadata := resp.Header.Get(panasasHTTPS3MetadataHeader)


### PR DESCRIPTION
## Description
Fixed number of issues in MinIO PanFS backend and
client for pan-config:
  * Fixed shadowing of readCloser variable that caused crash of minio
  * Removed 'data/' prefix from all configuration objects to match the virtual structure of '.minio.sys' bucket.
  * Fixed handling of prefix query in list opertaion in pan-config
  * Fixed empty return statement on error


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
