### PR TITLE
SG-573 Preserve object metadata when deleting bucket

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -782,10 +782,15 @@ func (fs *PANFSObjects) DeleteBucket(ctx context.Context, bucket string, opts De
 	// only remove content of tmp and multipart directories
 	for _, dir := range []string{tmpDir, mpartMetaPrefix} {
 		deletePath := pathJoin(bucketDir, panfsMetaDir, "."+dir)
+		logger.Info("Rename %s to %s", pathJoin(bucketDir, panfsMetaDir, dir), deletePath)
 		if err = PanRenameFile(pathJoin(bucketDir, panfsMetaDir, dir), deletePath); err != nil {
+			//if err = Rename(pathJoin(bucketDir, panfsMetaDir, dir), deletePath); err != nil {
+			logger.Info("Rename failed")
 			return toObjectErr(err, pathJoin(bucketDir, dir))
 		}
+		logger.Info("Remove %s", deletePath)
 		fsRemoveAll(ctx, deletePath) // TODO: delete in background?
+		logger.Info("Remove done!")
 	}
 	if fs.configAgent != nil {
 		noLockID := ""


### PR DESCRIPTION
## Description

- Updated delete bucket operation to do not touch user data and theirs metadata.
- The only tmp and multipart directories will be deleted during delete bucket operation

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
