### PR TITLE
SG-581 Buckets are returned via s3_client.list_bucket() function with an unnecessary "/" at the end.

### DIFF
--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -244,7 +244,7 @@ func testGetBucketPanFSPathHandler(obj ObjectLayer, instanceType, bucketName str
 			secretKey:          credentials.SecretKey,
 			expectedRespStatus: http.StatusOK,
 			panFSResponse: []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<PanFSPath>` + pathJoin(globalPanFSDefaultBucketPath, bucketName+"/") + `</PanFSPath>`),
+<PanFSPath>` + pathJoin(globalPanFSDefaultBucketPath, bucketName) + `</PanFSPath>`),
 			errorResponse: APIErrorResponse{},
 			shouldPass:    true,
 		},

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -595,8 +595,8 @@ func (fs *PANFSObjects) MakeBucketWithLocation(ctx context.Context, bucket strin
 	}
 
 	meta := newBucketMetadata(bucket)
-	// Save panfs path with trailing slash
-	meta.PanFSPath = retainSlash(bucketPanFSPath)
+	// Save panfs path without trailing slash
+	meta.PanFSPath = strings.TrimSuffix(bucketPanFSPath, "/")
 
 	if err := meta.Save(ctx, fs); err != nil {
 		return toObjectErr(err, bucket)

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -104,7 +104,7 @@ func TestPANFSGetBucketInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedPanFSBucketPath := pathJoin(disk, bucketName+"/")
+	expectedPanFSBucketPath := pathJoin(disk, bucketName)
 	if info.PanFSPath != expectedPanFSBucketPath {
 		t.Fatalf("wrong bucket panfs path, expected: %s, found: %s", expectedPanFSBucketPath, info.PanFSPath)
 	}


### PR DESCRIPTION
## Description

Store bucket `panfs-path` without trailing slash into the bucket metadata 

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
