### PR TITLE
SG-577: Review environment variables for MinIO

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -36,7 +36,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -161,12 +160,8 @@ func NewPANFSObjectLayer(ctx context.Context, fsPath string) (ObjectLayer, error
 		return nil, config.ErrUnableToWriteInBackend(err).Hint(hint)
 	}
 
-	// Assign a new UUID for FS minio mode. Each server instance
-	// gets its own UUID for temporary file transaction.
-	nodeDataSerial := env.Get(config.EnvPanUUID, mustGetUUID())
-	if _, err := uuid.Parse(nodeDataSerial); err != nil {
-		return nil, fmt.Errorf("can't parse uuid provided via env variable \"%s\". Value:\"%s\" Error: %w", config.EnvPanUUID, nodeDataSerial, err)
-	}
+	// initialize nodeDataSerial from environment variable or generate random UUID
+	nodeDataSerial := env.Get(config.EnvPanDataserial, mustGetUUID())
 
 	// Initialize meta volume, if volume already exists ignores it.
 	if err = initMetaVolumePANFS(fsPath, nodeDataSerial); err != nil {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -84,7 +84,7 @@ const (
 	EnvPanFSBucketPath       = "MINIO_PANFS_BUCKET_PATH"
 	EnvPanasasConfigAgentURL = "MINIO_PANFS_CONFIG_AGENT_URL"
 	EnvPanTmpDirsCount       = "MINIO_PANFS_TMP_DIRS_COUNT"
-	EnvPanUUID               = "MINIO_PANFS_DATASERIAL"
+	EnvPanDataserial         = "MINIO_PANFS_DATASERIAL"
 	EnvPanDefaultDirMode     = "MINIO_PANFS_DEFAULT_DIR_MODE"
 	EnvPanDefaultObjMode     = "MINIO_PANFS_DEFAULT_OBJ_MODE"
 	EnvPanDefaultOwner       = "MINIO_PANFS_DEFAULT_OWNER"


### PR DESCRIPTION
Do not require node dataserial to be a valid UUID.

## Description
Node dataserial is not a UUID, so we should allow any string from environment variable.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
