### PR TITLE
Buckets are returned via s3_client.list_bucket() function with an unnecessary "/" at the end.

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -728,7 +728,7 @@ func (fs *PANFSObjects) listBuckets(ctx context.Context) ([]BucketInfo, error) {
 		}
 
 		bucketInfos = append(bucketInfos, BucketInfo{
-			Name:      fi.Name(),
+			Name:      strings.TrimSuffix(meta.Name, "/"),
 			Created:   fi.ModTime(),
 			PanFSPath: meta.PanFSPath,
 		})


### PR DESCRIPTION
## Description

List bucket operation should return bucket name based on the its metadata not on the folder name (as the bucket path can be different with the bucket name)

## Motivation and Context


## How to test this PR?

Test result:
```
dmitri_zavadski@EPBYBREW0207:~/projects/minio-project/minio-mc$ ./mc mb local/test
Bucket created successfully `local/test`.
dmitri_zavadski@EPBYBREW0207:~/projects/minio-project/minio-mc$ ./mc mb local/test-1
Bucket created successfully `local/test-1`.
dmitri_zavadski@EPBYBREW0207:~/projects/minio-project/minio-mc$ ./mc mb local/test-2 --panfs-path ~/minio_panfs_gateway/outer/
Bucket created successfully `local/test-2`.
dmitri_zavadski@EPBYBREW0207:~/projects/minio-project/minio-mc$ ./mc ls local --json
{
 "status": "success",
 "type": "folder",
 "lastModified": "2023-04-20T10:59:12.187+03:00",
 "size": 0,
 "key": "test/",
 "etag": "",
 "url": "http://localhost:9000/",
 "versionOrdinal": 1
}
{
 "status": "success",
 "type": "folder",
 "lastModified": "2023-04-20T10:59:14.667+03:00",
 "size": 0,
 "key": "test-1/",
 "etag": "",
 "url": "http://localhost:9000/",
 "versionOrdinal": 1
}
{
 "status": "success",
 "type": "folder",
 "lastModified": "2023-04-20T10:59:28.475+03:00",
 "size": 0,
 "key": "test-2/",
 "etag": "",
 "url": "http://localhost:9000/",
 "versionOrdinal": 1
}
dmitri_zavadski@EPBYBREW0207:~/projects/minio-project/minio-mc$ ./mc stat local
Name      : test/
Size      : 0 B    
Type      : folder 
Metadata  :
  Versioning: Un-versioned
  Location: us-east-1
  Policy: none
  PanFS path: /home/dmitri_zavadski/minio_panfs_gateway/default/test/
Name      : test-1/
Size      : 0 B    
Type      : folder 
Metadata  :
  Versioning: Un-versioned
  Location: us-east-1
  Policy: none
  PanFS path: /home/dmitri_zavadski/minio_panfs_gateway/default/test-1/
Name      : test-2/
Size      : 0 B    
Type      : folder 
Metadata  :
  Versioning: Un-versioned
  Location: us-east-1
  Policy: none
  PanFS path: /home/dmitri_zavadski/minio_panfs_gateway/outer/
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
