### PR TITLE
SG-580: While trying to edit minio user new password is required

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1126,10 +1126,6 @@ func (sys *IAMSys) CreateUser(ctx context.Context, accessKey string, ureq madmin
 		return updatedAt, auth.ErrInvalidAccessKeyLength
 	}
 
-	if !auth.IsSecretKeyValid(ureq.SecretKey) {
-		return updatedAt, auth.ErrInvalidSecretKeyLength
-	}
-
 	updatedAt, err = sys.store.AddUser(ctx, accessKey, ureq)
 	if err != nil {
 		return updatedAt, err


### PR DESCRIPTION
Allow to update password and owner/group IDs for existing S3 user.

## Description
Allow to update individual fields (password, owner/group) for an S3 user. Please see inline commends in code for more information.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
