### PR TITLE
SG-597 minio mint "minio-go: testFunctionalV2" test fails with "Bucket minio-go-test-fzkcoynwx2qz5jwwnot found" error

### DIFF
--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -716,7 +716,11 @@ func (fs *PANFSObjects) listBuckets(ctx context.Context) ([]BucketInfo, error) {
 		if isReservedOrInvalidBucket(entry, false) {
 			continue
 		}
-		meta, err := fs.loadBucketMetadata(ctx, entry, true)
+
+		// We should load bucket metadata by its name (without trailing slash). Trailing slash in same cases
+		// breaks validation of assigned policy to the bucket and breaks bucket listing as well (policy validates
+		// that bucket name matches to the resource defined in policy
+		meta, err := fs.loadBucketMetadata(ctx, strings.TrimSuffix(entry, "/"), true)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Description

Remove trailing slash in list operation.

Note: this is intended to fix behavior related to local configuration. I didn't test (and don't know whether it is possible right now) with configuration agent. Probably, this may affect listing operation with configuration agent enabled - but I'm not sure.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
