### PR TITLE
SG-621: Updated IAM interface to return map of GroupDesc

### DIFF
--- a/cmd/admin-handlers-users_test.go
+++ b/cmd/admin-handlers-users_test.go
@@ -742,7 +742,8 @@ func (s *TestSuiteIAM) TestGroupAddRemove(c *check) {
 	if err != nil {
 		c.Fatalf("group list err: %v", err)
 	}
-	if !set.CreateStringSet(groups...).Contains(group) {
+	_, ok := groups[group]
+	if !ok {
 		c.Fatalf("created group not present!")
 	}
 	groupInfo, err := s.adm.GetGroupDescription(ctx, group)
@@ -822,7 +823,8 @@ func (s *TestSuiteIAM) TestGroupAddRemove(c *check) {
 	if err != nil {
 		c.Fatalf("group list err: %v", err)
 	}
-	if set.CreateStringSet(groups...).Contains(group) {
+	_, ok = groups[group]
+	if ok {
 		c.Fatalf("created group still present!")
 	}
 	groupInfo, err = s.adm.GetGroupDescription(ctx, group)

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1416,7 +1416,7 @@ func (sys *IAMSys) GetGroupDescription(group string) (gd madmin.GroupDesc, err e
 }
 
 // ListGroups - lists groups.
-func (sys *IAMSys) ListGroups(ctx context.Context) (r []string, err error) {
+func (sys *IAMSys) ListGroups(ctx context.Context) (r map[string]madmin.GroupDesc, err error) {
 	if !sys.Initialized() {
 		return r, errServerNotInitialized
 	}

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3447,7 +3447,7 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 				return info, errSRBackendIssue(errG)
 			}
 			groupDescMap := make(map[string]madmin.GroupDesc, len(groups))
-			for _, g := range groups {
+			for g := range groups {
 				groupDescMap[g], errG = globalIAMSys.GetGroupDescription(g)
 				if errG != nil {
 					return info, errSRBackendIssue(errG)

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 
 replace github.com/minio/pkg => github.com/panasasinc/minio-pkg v1.5.5-0.20230331124037-2837fe391278
 
-replace github.com/minio/madmin-go => github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741
+replace github.com/minio/madmin-go => github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2
 
 replace github.com/minio/mc v0.0.0-20221007160339-ec8687d57e36 => github.com/panasasinc/minio-mc v0.0.0-20230331094413-3947d76f8f35
 

--- a/go.sum
+++ b/go.sum
@@ -840,8 +840,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741 h1:pg5zCBu0vhE80JNDuJ2Nzy8zPJEhCMCOlEhN1f+n3q8=
-github.com/panasasinc/madmin-go v0.0.0-20230331061341-8fdaf3295741/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
+github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2 h1:mnuvPqRwcL6jtvTY3zwBo0Y5X774OWxbn7pAvWjcCaY=
+github.com/panasasinc/madmin-go v1.6.7-0.20230524085333-532553a0f7e2/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
 github.com/panasasinc/minio-go/v7 v7.0.0-20221206164009-5985ee51debf h1:H1tBUSBWU7Q4O4dpbJAaPKKu2lmpLEsFerl4XJ4xut0=
 github.com/panasasinc/minio-go/v7 v7.0.0-20221206164009-5985ee51debf/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/panasasinc/minio-mc v0.0.0-20230331094413-3947d76f8f35 h1:BKw75/V/YWxH1+Q78YDoeCm7jwn420hZZyQKL6WzZz4=


### PR DESCRIPTION
## Description
Updated MinIO IAM ListGroups interface to return map of GroupDesc structs instead of just group names. Also ListGroups was reworked to use cached IAM state instead of reloading it each time from IAM storage. 

## Motivation and Context
This change should significantly speedup S3 group listing via UI.

## How to test this PR?
Tested manually with updated _madmin-go_ and _minio-mc_ packages:

```
yauhenm@pavm31-9:.../git/minio-mc$ ./mc --json admin group list mypanfs
{
 "status": "success",
 "groupName": "admins",
 "members": [
  "test4"
 ],
 "groupStatus": "enabled",
 "groupPolicy": "readwrite"
}
{
 "status": "success",
 "groupName": "users",
 "members": [
  "test1",
  "test3"
 ],
 "groupStatus": "enabled",
 "groupPolicy": "readonly"
}
yauhenm@pavm31-9:.../git/minio-mc$ ./mc admin group list mypanfs
admins               enabled   readwrite            test4                                   
users                enabled   readonly             test1,test3  
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
