### PR TITLE
SG-674: Move bucket metadata to Config Agent

### DIFF
--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -242,7 +242,7 @@ func (c *Client) deleteObjects(objectName string, byPrefix bool, lockID ...strin
 		hasQuery = true
 	}
 	if byPrefix {
-		q.Add("by_prefix", "1")
+		q.Add("by_prefix", "true")
 		hasQuery = true
 	}
 	if hasQuery {

--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -125,7 +125,9 @@ func closeResponseBody(resp *http.Response) {
 	}
 }
 
-func (c *Client) listConfigObjects(prefix, delimiter string) ([]string, error) {
+// GetObjectsList returns a list of objects with names beginning with the
+// specified prefix.
+func (c *Client) GetObjectsList(prefix string) ([]string, error) {
 	req, err := c.makeConfigAgentRequest("configs")
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for /objects with prefix %q: %s\n", prefix, err)
@@ -134,9 +136,6 @@ func (c *Client) listConfigObjects(prefix, delimiter string) ([]string, error) {
 
 	q := req.URL.Query()
 	q.Add("prefix", prefix)
-	if delimiter != "" {
-		q.Add("delimiter", delimiter)
-	}
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := c.httpClient.Do(req)
@@ -163,40 +162,6 @@ func (c *Client) listConfigObjects(prefix, delimiter string) ([]string, error) {
 	}
 
 	return result, nil
-}
-
-// GetObjectsList returns a list of objects with names beginning with the
-// specified prefix.
-func (c *Client) GetObjectsList(prefix string) ([]string, error) {
-	return c.listConfigObjects(prefix, "")
-}
-
-// GetObjectPrefixes returns a list of shared object name prefixes.
-//
-// GetObjectPrefixes will group the objects with names matching the specified
-// prefix by trimming the parts beginning after the first occurrence of the
-// delimiter after the prefix.
-// E.g. let's assume 5 objects are stored with the following keys:
-// - "/home/user1/object1"
-// - "/home/user1/object2"
-// - "/home/user2/object1"
-// - "/home/user2/object2"
-// - "/etc/share_object"
-// In this case GetObjectPrefixes("/home/", "/") will return the following list
-// of common prefixes:
-// - "/home/user1",
-// - "/home/user2".
-//
-// This will be done by performing the following algorithm:
-// /home/                 - prefix
-// /home/user1/object1    - object name
-// ^^^^^^                 - matches the prefix
-//
-//            ^           - is the first delimiter AFTER the prefix
-//
-//            ^^^^^^^^    - delimiter with the following part is trimmed
-func (c *Client) GetObjectPrefixes(prefix, delimiter string) ([]string, error) {
-	return c.listConfigObjects(prefix, delimiter)
 }
 
 // GetObject returns an object:

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -779,10 +779,7 @@ func (fs *PANFSObjects) DeleteBucket(ctx context.Context, bucket string, opts De
 	}
 
 	globalBucketMetadataCache.Delete(bucket)
-	if fs.configAgent != nil {
-		// NOTE:llorens: do nothing, deleteBucketMetadata() will do
-		// everything that's needed.
-	} else {
+	if fs.configAgent == nil {
 		if err = fsRemoveAll(ctx, pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket)); err != nil {
 			return toObjectErr(err, bucket)
 		}

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -56,7 +56,6 @@ import (
 )
 
 const (
-	panfsBucketListPrefix     = "buckets"
 	panfsConfigAgentNamespace = "s3"
 )
 


### PR DESCRIPTION
## Description
This change set moves bucket metadata into the Config Agent.

## Motivation and Context


## How to test this PR?
Update the Config Agent instance to support grouping object prefixes and deletion by prefix. Run operations related to buckets (e.g. bucket creation, deletion, listing), perform Config Agent restarts in between to make sure the data is correctly preserved.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
