### PR TITLE
SG-694: Prevent Panasas config.Client from hanging in case of communication problems

### DIFF
--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -35,7 +35,8 @@ type ErrUnexpectedHTTPStatus uint
 // ErrUnexpectedContentType informs about unexpected HTTP response content type
 type ErrUnexpectedContentType string
 
-const ConfigAgentOperationTimeout = 10 * time.Second
+// ConfigAgentOperationTimeout is a timeout for HTTP requests to the Config Agent
+const ConfigAgentOperationTimeout = 30 * time.Second
 
 func (e ErrUnexpectedHTTPStatus) Error() string {
 	return fmt.Sprintf("Unexpected HTTP status: %v", uint(e))

--- a/cmd/panasas/config/client.go
+++ b/cmd/panasas/config/client.go
@@ -2,15 +2,16 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"path"
 	"strings"
+	"time"
 )
 
 const panasasHTTPS3MetadataHeader string = "Panasas-Config-Object-Metadata"
@@ -33,6 +34,8 @@ type ErrUnexpectedHTTPStatus uint
 
 // ErrUnexpectedContentType informs about unexpected HTTP response content type
 type ErrUnexpectedContentType string
+
+const ConfigAgentOperationTimeout = 10 * time.Second
 
 func (e ErrUnexpectedHTTPStatus) Error() string {
 	return fmt.Sprintf("Unexpected HTTP status: %v", uint(e))
@@ -64,7 +67,7 @@ func NewClient(agentURL, namespace string) *Client {
 	return &client
 }
 
-func (c *Client) getConfigAgentURL(elem ...string) (*url.URL, error) {
+func (c *Client) getConfigAgentURL(elem ...string) string {
 	elems := make([]string, 0, 2+len(elem))
 	elems = append(elems, "namespaces", c.namespace)
 	elems = append(elems, elem...)
@@ -81,27 +84,21 @@ func (c *Client) getConfigAgentURL(elem ...string) (*url.URL, error) {
 		separator = ""
 	}
 
-	return url.Parse(strings.Join([]string{c.agentURL, urlPath[offset:]}, separator))
+	return strings.Join([]string{c.agentURL, urlPath[offset:]}, separator)
 }
 
-func (c *Client) makeConfigAgentRequest(urlElem ...string) (*http.Request, error) {
-	u, err := c.getConfigAgentURL(urlElem...)
+func (c *Client) newConfigAgentRequest(ctx context.Context, urlElem ...string) (*http.Request, context.CancelFunc, error) {
+	u := c.getConfigAgentURL(urlElem...)
+
+	ctx, cancel := context.WithTimeout(ctx, ConfigAgentOperationTimeout)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		log.Printf("Failed formatting URL for %v: %s\n", urlElem, err)
-		return nil, err
+		cancel()
+		return nil, nil, err
 	}
 
-	req := http.Request{
-		Method:        http.MethodGet,
-		URL:           u,
-		Proto:         "HTTP/1.1",
-		ProtoMajor:    1,
-		ProtoMinor:    1,
-		Header:        make(http.Header),
-		Host:          u.Host,
-		ContentLength: 0,
-	}
-	return &req, nil
+	return req, cancel, err
 }
 
 // closeResponseBody close non nil response with any response Body.
@@ -127,12 +124,13 @@ func closeResponseBody(resp *http.Response) {
 
 // GetObjectsList returns a list of objects with names beginning with the
 // specified prefix.
-func (c *Client) GetObjectsList(prefix string) ([]string, error) {
-	req, err := c.makeConfigAgentRequest("configs")
+func (c *Client) GetObjectsList(ctx context.Context, prefix string) ([]string, error) {
+	req, cancel, err := c.newConfigAgentRequest(ctx, "configs")
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for /objects with prefix %q: %s\n", prefix, err)
 		return []string{}, err
 	}
+	defer cancel()
 
 	q := req.URL.Query()
 	q.Add("prefix", prefix)
@@ -170,14 +168,15 @@ func (c *Client) GetObjectsList(prefix string) ([]string, error) {
 // The caller is responsible for calling Close() on the dataReader.
 // If err is not nil, dataReader and metadata are assumed invalid and should
 // not be used.
-func (c *Client) GetObject(objectName string) (dataReader io.ReadCloser, oi *ObjectInfo, err error) {
+func (c *Client) GetObject(ctx context.Context, objectName string) (dataReader io.ReadCloser, oi *ObjectInfo, err error) {
 	base := "configs"
 
-	req, err := c.makeConfigAgentRequest(base, objectName)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, objectName)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return nil, nil, err
 	}
+	defer cancel()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -224,14 +223,15 @@ func (c *Client) GetObject(objectName string) (dataReader io.ReadCloser, oi *Obj
 	return resp.Body, oi, nil
 }
 
-func (c *Client) deleteObjects(objectName string, byPrefix bool, lockID ...string) error {
+func (c *Client) deleteObjects(ctx context.Context, objectName string, byPrefix bool, lockID ...string) error {
 	base := "configs"
 
-	req, err := c.makeConfigAgentRequest(base, objectName)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, objectName)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return err
 	}
+	defer cancel()
 
 	req.Method = http.MethodDelete
 
@@ -274,25 +274,26 @@ func (c *Client) deleteObjects(objectName string, byPrefix bool, lockID ...strin
 }
 
 // DeleteObject deletes an object with matching name
-func (c *Client) DeleteObject(objectName string, lockID ...string) error {
-	return c.deleteObjects(objectName, false, lockID...)
+func (c *Client) DeleteObject(ctx context.Context, objectName string, lockID ...string) error {
+	return c.deleteObjects(ctx, objectName, false, lockID...)
 }
 
 // DeleteObjectsByPrefix deletes all objects with names starting with the
 // specified prefix.
-func (c *Client) DeleteObjectsByPrefix(prefix string) error {
-	return c.deleteObjects(prefix, true)
+func (c *Client) DeleteObjectsByPrefix(ctx context.Context, prefix string) error {
+	return c.deleteObjects(ctx, prefix, true)
 }
 
 // PutObject stores an object of a given name in the config agent
-func (c *Client) PutObject(objectName string, data io.Reader, lockID ...string) error {
+func (c *Client) PutObject(ctx context.Context, objectName string, data io.Reader, lockID ...string) error {
 	base := "configs"
 
-	req, err := c.makeConfigAgentRequest(base, objectName)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, objectName)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return err
 	}
+	defer cancel()
 
 	if data == nil {
 		data = bytes.NewBuffer([]byte{})
@@ -333,14 +334,15 @@ func (c *Client) PutObject(objectName string, data io.Reader, lockID ...string) 
 }
 
 // GetObjectInfo fetches object metadata from the config agent
-func (c *Client) GetObjectInfo(objectName string) (oi *ObjectInfo, err error) {
+func (c *Client) GetObjectInfo(ctx context.Context, objectName string) (oi *ObjectInfo, err error) {
 	base := "configs"
 
-	req, err := c.makeConfigAgentRequest(base, objectName)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, objectName)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return nil, err
 	}
+	defer cancel()
 
 	req.Method = http.MethodHead
 	resp, err := c.httpClient.Do(req)
@@ -380,8 +382,8 @@ func (c *Client) GetRecentConfigRevision() (revision string, err error) {
 	return *c.configRevision, nil
 }
 
-func (c *Client) fetchNamespaceInfo(endpoint, httpMethod string) (*NamespaceInfo, error) {
-	req, err := c.makeConfigAgentRequest(endpoint)
+func (c *Client) fetchNamespaceInfo(ctx context.Context, endpoint, httpMethod string) (*NamespaceInfo, error) {
+	req, cancel, err := c.newConfigAgentRequest(ctx, endpoint)
 	if err != nil {
 		if endpoint != "" {
 			log.Printf("Failed preparing HTTP request object for /namespaces/%s/%s: %s\n", c.namespace, endpoint, err)
@@ -391,6 +393,7 @@ func (c *Client) fetchNamespaceInfo(endpoint, httpMethod string) (*NamespaceInfo
 		return nil, err
 	}
 	req.Method = httpMethod
+	defer cancel()
 
 	resp, err := c.httpClient.Do(req)
 	defer closeResponseBody(resp)
@@ -410,11 +413,11 @@ func (c *Client) fetchNamespaceInfo(endpoint, httpMethod string) (*NamespaceInfo
 }
 
 // GetConfigRevision queries the config agent for the current config revision
-func (c *Client) GetConfigRevision() (revision string, err error) {
+func (c *Client) GetConfigRevision(ctx context.Context) (revision string, err error) {
 	endpoint := ""
 	method := http.MethodGet
 
-	info, err := c.fetchNamespaceInfo(endpoint, method)
+	info, err := c.fetchNamespaceInfo(ctx, endpoint, method)
 	if err != nil {
 		return "", err
 	}
@@ -426,33 +429,34 @@ func (c *Client) GetConfigRevision() (revision string, err error) {
 
 // UpdateConfigRevision forces Panasas config agent to generate a new revision
 // string
-func (c *Client) UpdateConfigRevision() (info *NamespaceInfo, err error) {
+func (c *Client) UpdateConfigRevision(ctx context.Context) (info *NamespaceInfo, err error) {
 	endpoint := "actions/Revision.Update"
 	method := http.MethodPost
 
-	return c.fetchNamespaceInfo(endpoint, method)
+	return c.fetchNamespaceInfo(ctx, endpoint, method)
 }
 
 // ClearCache triggers Panasas config agent cache purging
-func (c *Client) ClearCache() (info *NamespaceInfo, err error) {
+func (c *Client) ClearCache(ctx context.Context) (info *NamespaceInfo, err error) {
 	endpoint := "actions/Cache.Clear"
 	method := http.MethodPost
 
-	return c.fetchNamespaceInfo(endpoint, method)
+	return c.fetchNamespaceInfo(ctx, endpoint, method)
 }
 
 // GetObjectLock tries to get a write or read lock on the specified object
 // Set "read" to true to obtain a non-exclusive read lock.
 // Returns the ID of the obtained lock. This ID can be then used in the calls
 // to ReleaseObjectLock(), PutObject(), DeleteObject().
-func (c *Client) GetObjectLock(objectName string, read bool) (lockID string, err error) {
+func (c *Client) GetObjectLock(ctx context.Context, objectName string, read bool) (lockID string, err error) {
 	base := "/lock"
 
-	req, err := c.makeConfigAgentRequest(base, objectName)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, objectName)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, objectName, err)
 		return "", err
 	}
+	defer cancel()
 
 	req.Method = http.MethodPost
 
@@ -497,13 +501,14 @@ func (c *Client) GetObjectLock(objectName string, read bool) (lockID string, err
 // ReleaseObjectLock releases a previously obtained object lock
 // Will return ErrNotFound if the specified lock has not been found or the lock
 // has expired since it was obtained.
-func (c *Client) ReleaseObjectLock(lockID string) (err error) {
+func (c *Client) ReleaseObjectLock(ctx context.Context, lockID string) (err error) {
 	base := "/locks"
-	req, err := c.makeConfigAgentRequest(base, lockID)
+	req, cancel, err := c.newConfigAgentRequest(ctx, base, lockID)
 	if err != nil {
 		log.Printf("Failed preparing HTTP request object for %v with name %q: %s\n", base, lockID, err)
 		return err
 	}
+	defer cancel()
 
 	req.Method = http.MethodDelete
 

--- a/cmd/panfs.go
+++ b/cmd/panfs.go
@@ -689,7 +689,7 @@ func (fs *PANFSObjects) listBuckets(ctx context.Context) ([]BucketInfo, error) {
 		// objects included in the "buckets" directory but ignore a
 		// directory/object whose name would begin with "buckets".
 		prefix := pathJoin(minioMetaBucket, bucketMetaPrefix, SlashSeparator)
-		entries, err = fs.configAgent.GetObjectsList(prefix)
+		entries, err = fs.configAgent.GetObjectsList(ctx, prefix)
 		if err == nil {
 			bucketSet := set.NewStringSet()
 			// The entries will have a prefix. In order to get the
@@ -982,7 +982,7 @@ func (fs *PANFSObjects) GetObjectNInfo(ctx context.Context, bucket, object strin
 	if fs.isConfigAgentObject(bucket, object) {
 		var objectInfo *panconfig.ObjectInfo
 		objectName := pathJoin(bucket, object)
-		readCloser, objectInfo, err = fs.configAgent.GetObject(objectName)
+		readCloser, objectInfo, err = fs.configAgent.GetObject(ctx, objectName)
 		if err == nil {
 			size = objectInfo.Size()
 			io.Copy(io.Discard, io.LimitReader(readCloser, off))
@@ -1101,7 +1101,7 @@ func (fs *PANFSObjects) getObjectInfoNoFSLock(ctx context.Context, bucket, objec
 	// Stat the file to get file size.
 	var fi os.FileInfo
 	if fs.isConfigAgentObject(bucket, object) {
-		fi, err = fs.configAgent.GetObjectInfo(pathJoin(bucket, object))
+		fi, err = fs.configAgent.GetObjectInfo(ctx, pathJoin(bucket, object))
 	} else {
 		fi, err = fsStatFile(ctx, pathJoin(bucketDir, object))
 	}
@@ -1165,7 +1165,7 @@ func (fs *PANFSObjects) getObjectInfo(ctx context.Context, bucket, object string
 	// Stat the file to get file size.
 	var fi os.FileInfo
 	if fs.isConfigAgentObject(bucket, object) {
-		fi, err = fs.configAgent.GetObjectInfo(pathJoin(bucket, object))
+		fi, err = fs.configAgent.GetObjectInfo(ctx, pathJoin(bucket, object))
 	} else {
 		fi, err = fsStatFile(ctx, pathJoin(bucketDir, object))
 	}
@@ -1356,7 +1356,7 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 
 	if fs.isConfigAgentObject(bucket, object) {
 		fsNSObjPath = pathJoin(bucket, object)
-		retErr = fs.configAgent.PutObject(fsNSObjPath, data)
+		retErr = fs.configAgent.PutObject(ctx, fsNSObjPath, data)
 		if retErr != nil {
 			return ObjectInfo{}, retErr
 		}
@@ -1405,7 +1405,7 @@ func (fs *PANFSObjects) putObject(ctx context.Context, bucket string, object str
 	// Stat the file to fetch timestamp, size.
 	var fi os.FileInfo
 	if fs.isConfigAgentObject(bucket, object) {
-		fi, err = fs.configAgent.GetObjectInfo(pathJoin(bucket, object))
+		fi, err = fs.configAgent.GetObjectInfo(ctx, pathJoin(bucket, object))
 	} else {
 		fi, err = fsStatFile(ctx, fsNSObjPath)
 	}
@@ -1499,10 +1499,10 @@ func (fs *PANFSObjects) DeleteObject(ctx context.Context, bucket, object string,
 	if fs.isConfigAgentObject(bucket, object) {
 		objectName := pathJoin(bucket, object)
 		if opts.DeletePrefix {
-			err = fs.configAgent.DeleteObjectsByPrefix(objectName)
+			err = fs.configAgent.DeleteObjectsByPrefix(ctx, objectName)
 		} else {
 			noLock := ""
-			err = fs.configAgent.DeleteObject(objectName, noLock)
+			err = fs.configAgent.DeleteObject(ctx, objectName, noLock)
 		}
 	} else {
 		err = fsDeleteFile(ctx, pathJoin(bucketDir), pathJoin(bucketDir, object))
@@ -1606,7 +1606,7 @@ func (fs *PANFSObjects) listDirFactory() ListDirFunc {
 		var agentEntries []string
 		if fs.configAgent != nil {
 			prefix := pathJoin(bucket, prefixDir)
-			agentEntries, err = fs.configAgent.GetObjectsList(prefix)
+			agentEntries, err = fs.configAgent.GetObjectsList(context.Background(), prefix)
 			if err != nil {
 				return false, nil, false
 			}


### PR DESCRIPTION
## Description
Time-outs have been added to the code performing HTTP request in the Panasas Config Agent client.

## Motivation and Context
The goal of this change is to maintain MinIO's responsiveness in case of Configuration Agent failure (e.g. deadlock preventing it from responding to an API call).

## How to test this PR?
This PR has been tested manually by running the Config Agent under a debugger and setting breakpoints in relevant places.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
