### PR TITLE
SG-730: Move meta bucket away from normal buckets storage

### DIFF
--- a/cmd/format-fs.go
+++ b/cmd/format-fs.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/minio/minio/internal/config"
@@ -163,6 +164,10 @@ func formatFSMigrate(ctx context.Context, wlk *lock.LockedFile, fsPath string) e
 
 // Creates a new format.json if unformatted.
 func createFormatFS(fsFormatPath string) error {
+	fsFormatPathDir := filepath.Dir(fsFormatPath)
+	if err := os.MkdirAll(fsFormatPathDir, 0o777); err != nil {
+		return err
+	}
 	// Attempt a write lock on formatConfigFile `format.json`
 	// file stored in minioMetaBucket(.minio.sys) directory.
 	lk, err := lock.TryLockedOpenFile(fsFormatPath, os.O_RDWR|os.O_CREATE, 0o666)

--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -39,11 +39,11 @@ func TestNewPANFS(t *testing.T) {
 	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer os.RemoveAll(disk)
 
-	_, err := NewPANFSObjectLayer(ctx, "")
+	_, err := NewPANFSObjectLayer(ctx, "", "")
 	if err != errInvalidArgument {
 		t.Errorf("Expecting error invalid argument, got %s", err)
 	}
-	_, err = NewPANFSObjectLayer(ctx, disk)
+	_, err = NewPANFSObjectLayer(ctx, disk, disk)
 	if err != nil {
 		errMsg := "Unable to recognize backend format, Drive is not in FS format."
 		if err.Error() == errMsg {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -239,7 +239,7 @@ func initPanFSObjects(fs string) (obj ObjectLayer, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	obj, err = NewPANFSObjectLayer(ctx, fs)
+	obj, err = NewPANFSObjectLayer(ctx, fs, fs)
 	if err != nil {
 		return
 		// t.Fatal(err)


### PR DESCRIPTION
The environment variable MINIO_PANFS_METABUCKET_PATH can be used to specify the place where the meta bucket will be placed. By default the metabucket is placed in /var/lib/minio.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
