### PR TITLE
SG-695 Obsolete bucket information is preserved after volume with S3 buckets removal

### DIFF
--- a/cmd/panfs_test.go
+++ b/cmd/panfs_test.go
@@ -111,7 +111,7 @@ func TestPANFSGetBucketInfo(t *testing.T) {
 	// Test with non-existent bucket
 	_, err = fs.GetBucketInfo(GlobalContext, "a", BucketOptions{})
 	if !isSameType(err, BucketNotFound{}) {
-		t.Fatal("BucketNotFound error not returned")
+		t.Fatalf("Expected error: %v, found: %v", BucketNotFound{}, err)
 	}
 
 	// Check for buckets and should get disk not found.


### PR DESCRIPTION
## Description

This change updates minio to allow listing and removing "obsolete" buckets. Obsolete bucket is a bucket which has valid metadata stored in config agent but the bucket folder was deleted for some reason from disk.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
